### PR TITLE
wa: ignore senderKeyDistributionMessage in unhandled payload diagnostics

### DIFF
--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -180,7 +180,7 @@ func markUnhandledPayload(m *waProto.Message, pm *ParsedMessage) {
 	var names []string
 	m.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, _ protoreflect.Value) bool {
 		switch fd.Name() {
-		case "messageContextInfo":
+		case "messageContextInfo", "senderKeyDistributionMessage":
 			return true
 		}
 		names = append(names, string(fd.Name()))

--- a/internal/wa/unhandled_payload_test.go
+++ b/internal/wa/unhandled_payload_test.go
@@ -65,6 +65,19 @@ func TestMarkUnhandledPayloadIgnoresMessageContextInfo(t *testing.T) {
 	}
 }
 
+// senderKeyDistributionMessage is a Signal/WhatsApp protocol message for group
+// session key setup; it carries no user content and is not an unhandled payload.
+func TestMarkUnhandledPayloadIgnoresSenderKeyDistributionMessage(t *testing.T) {
+	pm := ParseLiveMessage(liveEvent(&waProto.Message{
+		SenderKeyDistributionMessage: &waProto.SenderKeyDistributionMessage{
+			GroupID: proto.String("123@g.us"),
+		},
+	}))
+	if pm.UnhandledPayload != "" {
+		t.Fatalf("expected senderKeyDistributionMessage to be ignored, got %q", pm.UnhandledPayload)
+	}
+}
+
 // An empty message has nothing to report; flagging it would fire on every
 // keep-alive-shaped payload.
 func TestMarkUnhandledPayloadIgnoresEmptyMessage(t *testing.T) {


### PR DESCRIPTION
### Summary
`senderKeyDistributionMessage` is a Signal/WhatsApp group session key distribution protocol message. It does not carry user chat content and shouldn't trigger an `unhandled payload senderKeyDistributionMessage` warning during sync/history replay.

### Changes
- Exclude `senderKeyDistributionMessage` in `markUnhandledPayload`
- Add unit test to verify it is ignored