### PR TITLE
feat: add opt-in optimized sync retention

### DIFF
--- a/cmd/wacli/accounts.go
+++ b/cmd/wacli/accounts.go
@@ -82,6 +82,7 @@ func newAccountsAddCmd(flags *rootFlags) *cobra.Command {
 		Short: "Add an account and authenticate it",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.optimized.capture(cmd)
 			if err := flags.requireWritable(); err != nil {
 				return err
 			}
@@ -145,7 +146,7 @@ func newAccountsAddCmd(flags *rootFlags) *cobra.Command {
 			if !flags.asJSON {
 				fmt.Fprintf(os.Stdout, "Account %s added at %s\n", name, added.StoreDir)
 			}
-			res, err := runAuth(flags, opts)
+			res, err := runAuth(flags, opts, cmd)
 			if err != nil {
 				return err
 			}

--- a/cmd/wacli/auth.go
+++ b/cmd/wacli/auth.go
@@ -11,9 +11,13 @@ import (
 	"github.com/mdp/qrterminal/v3"
 	appPkg "github.com/openclaw/wacli/internal/app"
 	"github.com/openclaw/wacli/internal/out"
+	"github.com/openclaw/wacli/internal/store"
 	"github.com/openclaw/wacli/internal/wa"
 	"github.com/spf13/cobra"
+	"go.mau.fi/whatsmeow/proto/waCompanionReg"
+	wmstore "go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/types"
+	"google.golang.org/protobuf/proto"
 )
 
 type authOptions struct {
@@ -22,6 +26,7 @@ type authOptions struct {
 	downloadMedia bool
 	qrFormat      string
 	phone         string
+	optimized     optimizedFlags
 }
 
 type validatedAuthOptions struct {
@@ -36,7 +41,8 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 		Use:   "auth",
 		Short: "Authenticate with WhatsApp (QR) and bootstrap sync",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			res, err := runAuth(flags, opts)
+			opts.optimized.capture(cmd)
+			res, err := runAuth(flags, opts, cmd)
 			if err != nil {
 				return err
 			}
@@ -67,9 +73,10 @@ func addAuthFlags(cmd *cobra.Command, opts *authOptions) {
 	cmd.Flags().BoolVar(&opts.downloadMedia, "download-media", false, "download media in the background during sync")
 	cmd.Flags().StringVar(&opts.qrFormat, "qr-format", "terminal", "QR output format: terminal or text")
 	cmd.Flags().StringVar(&opts.phone, "phone", "", "pair by phone number instead of QR code")
+	addOptimizedFlags(cmd, &opts.optimized)
 }
 
-func runAuth(flags *rootFlags, opts authOptions) (appPkg.SyncResult, error) {
+func runAuth(flags *rootFlags, opts authOptions, cmd *cobra.Command) (appPkg.SyncResult, error) {
 	if err := flags.requireWritable(); err != nil {
 		return appPkg.SyncResult{}, err
 	}
@@ -89,6 +96,15 @@ func runAuth(flags *rootFlags, opts authOptions) (appPkg.SyncResult, error) {
 		return appPkg.SyncResult{}, err
 	}
 	defer closeApp(a, lk)
+	policy, err := optimizedPolicyForApp(a, cmd, opts.optimized)
+	if err != nil {
+		return appPkg.SyncResult{}, err
+	}
+	if policy != nil && policy.Enabled {
+		applyOptimizedHistorySyncConfig(*policy)
+	} else if stored, err := a.DB().SyncOptimizationPolicy(); err == nil && stored.Enabled {
+		applyOptimizedHistorySyncConfig(stored)
+	}
 
 	mode := appPkg.SyncModeBootstrap
 	if opts.follow {
@@ -114,7 +130,19 @@ func runAuth(flags *rootFlags, opts authOptions) (appPkg.SyncResult, error) {
 		MaxMessages:     maxMessages,
 		MaxDBSizeBytes:  maxDBSize,
 		WarnNoLimits:    true,
+		Optimization:    policy,
 	})
+}
+
+func applyOptimizedHistorySyncConfig(policy store.SyncOptimizationPolicy) {
+	if wmstore.DeviceProps.HistorySyncConfig == nil {
+		wmstore.DeviceProps.HistorySyncConfig = &waCompanionReg.DeviceProps_HistorySyncConfig{}
+	}
+	c := wmstore.DeviceProps.HistorySyncConfig
+	c.FullSyncDaysLimit = proto.Uint32(uint32(policy.HistoryDays))
+	c.RecentSyncDaysLimit = proto.Uint32(uint32(policy.HistoryDays))
+	c.InitialSyncMaxMessagesPerChat = proto.Uint32(uint32(policy.MaxMessagesPerChat))
+	c.SupportCallLogHistory = proto.Bool(policy.PersistCalls)
 }
 
 func validateAuthOptions(flags *rootFlags, opts authOptions) (validatedAuthOptions, error) {

--- a/cmd/wacli/optimized.go
+++ b/cmd/wacli/optimized.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openclaw/wacli/internal/store"
+	"github.com/spf13/cobra"
+)
+
+type optimizedFlags struct {
+	enabled, excludeArchived, pruneEvicted, persistCalls, persistStatuses bool
+	maxChats, historyDays, messagesPerChat                                int
+	changed, optimizedSet, tuning                                         bool
+}
+
+func addOptimizedFlags(cmd *cobra.Command, f *optimizedFlags) {
+	cmd.Flags().BoolVar(&f.enabled, "optimized", false, "persist a bounded, privacy-focused local message index")
+	cmd.Flags().IntVar(&f.maxChats, "max-chats", 0, "maximum active chats retained by optimized sync")
+	cmd.Flags().BoolVar(&f.excludeArchived, "exclude-archived", true, "exclude archived chats in optimized sync")
+	cmd.Flags().IntVar(&f.historyDays, "history-days", 0, "initial history days requested while pairing in optimized sync")
+	cmd.Flags().IntVar(&f.messagesPerChat, "history-messages-per-chat", 0, "messages retained per chat in optimized sync")
+	cmd.Flags().BoolVar(&f.pruneEvicted, "prune-evicted-chats", true, "prune messages from chats evicted by optimized sync")
+	cmd.Flags().BoolVar(&f.persistCalls, "persist-calls", false, "persist call records in optimized sync")
+	cmd.Flags().BoolVar(&f.persistStatuses, "persist-statuses", false, "persist WhatsApp Status records in optimized sync")
+	cmd.Flags().Bool("confirm", false, "confirm irreversible optimized-store cleanup")
+}
+
+func (f *optimizedFlags) capture(cmd *cobra.Command) {
+	f.optimizedSet = cmd.Flags().Changed("optimized")
+	f.tuning = cmd.Flags().Changed("max-chats") || cmd.Flags().Changed("exclude-archived") || cmd.Flags().Changed("history-days") || cmd.Flags().Changed("history-messages-per-chat") || cmd.Flags().Changed("prune-evicted-chats") || cmd.Flags().Changed("persist-calls") || cmd.Flags().Changed("persist-statuses")
+	f.changed = f.optimizedSet || f.tuning
+}
+
+func resolveOptimizedPolicy(existing store.SyncOptimizationPolicy, f optimizedFlags) (store.SyncOptimizationPolicy, bool, error) {
+	if !f.changed {
+		return existing, false, nil
+	}
+	p := existing
+	if f.optimizedSet && !f.enabled {
+		if f.tuning {
+			return p, false, fmt.Errorf("optimized tuning flags require --optimized")
+		}
+		p.Enabled = false
+		return p, true, nil
+	}
+	if !p.Enabled || f.enabled {
+		p = store.DefaultSyncOptimizationPolicy()
+	}
+	p.Enabled = true
+	if f.maxChats > 0 {
+		p.MaxChats = f.maxChats
+	}
+	if f.historyDays > 0 {
+		p.HistoryDays = f.historyDays
+	}
+	if f.messagesPerChat > 0 {
+		p.MaxMessagesPerChat = f.messagesPerChat
+	}
+	p.ExcludeArchived, p.PruneEvictedChats, p.PersistCalls, p.PersistStatuses = f.excludeArchived, f.pruneEvicted, f.persistCalls, f.persistStatuses
+	if err := p.Validate(); err != nil {
+		return p, false, err
+	}
+	return p, true, nil
+}
+
+func optimizedPolicyForApp(a interface{ DB() *store.DB }, cmd *cobra.Command, f optimizedFlags) (*store.SyncOptimizationPolicy, error) {
+	existing, err := a.DB().SyncOptimizationPolicy()
+	if err != nil {
+		return nil, err
+	}
+	p, changed, err := resolveOptimizedPolicy(existing, f)
+	if err != nil || !changed {
+		return nil, err
+	}
+	if p.Enabled && !existing.Enabled {
+		var messageCount int64
+		if err := a.DB().Raw().QueryRow(`SELECT COUNT(*) FROM messages`).Scan(&messageCount); err != nil {
+			return nil, err
+		}
+		confirmed, _ := cmd.Flags().GetBool("confirm")
+		if messageCount > 0 && !confirmed {
+			return nil, fmt.Errorf("optimized activation will prune local history; rerun with --confirm")
+		}
+		if err := removeOptimizedLocalMedia(a.DB()); err != nil {
+			return nil, err
+		}
+	}
+	return &p, nil
+}
+
+func removeOptimizedLocalMedia(db *store.DB) error {
+	paths, err := db.AllLocalMediaPaths()
+	if err != nil {
+		return fmt.Errorf("list local media for optimized cleanup: %w", err)
+	}
+	for _, path := range paths {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove local media %q: %w", path, err)
+		}
+	}
+	if err := db.ClearAllLocalMediaPaths(); err != nil {
+		return fmt.Errorf("clear local media records: %w", err)
+	}
+	return nil
+}

--- a/cmd/wacli/optimized_test.go
+++ b/cmd/wacli/optimized_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/openclaw/wacli/internal/store"
+)
+
+func TestResolveOptimizedPolicyPresetAndDisable(t *testing.T) {
+	p, changed, err := resolveOptimizedPolicy(store.SyncOptimizationPolicy{}, optimizedFlags{enabled: true, changed: true, optimizedSet: true})
+	if err != nil || !changed || !p.Enabled || p.MaxChats != 100 || p.MaxMessagesPerChat != 50 {
+		t.Fatalf("preset = %+v, changed=%t, err=%v", p, changed, err)
+	}
+	p, changed, err = resolveOptimizedPolicy(p, optimizedFlags{changed: true, optimizedSet: true})
+	if err != nil || !changed || p.Enabled {
+		t.Fatalf("disabled policy = %+v, changed=%t, err=%v", p, changed, err)
+	}
+}
+
+func TestResolveOptimizedPolicyTuningImpliesEnabled(t *testing.T) {
+	p, changed, err := resolveOptimizedPolicy(store.SyncOptimizationPolicy{}, optimizedFlags{changed: true, tuning: true, maxChats: 25, excludeArchived: false, pruneEvicted: true})
+	if err != nil || !changed || !p.Enabled || p.MaxChats != 25 || p.ExcludeArchived {
+		t.Fatalf("policy = %+v, changed=%t, err=%v", p, changed, err)
+	}
+}

--- a/cmd/wacli/sync.go
+++ b/cmd/wacli/sync.go
@@ -28,11 +28,13 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	var webhookEventsFlag string
 	var sendSpacingFlag string
 	var storage syncStorageLimitFlags
+	var optimized optimizedFlags
 
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync messages (requires prior auth; never shows QR)",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			optimized.capture(cmd)
 			if err := flags.requireWritable(); err != nil {
 				return err
 			}
@@ -75,6 +77,10 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 			defer closeApp(a, lk)
 
 			if err := a.EnsureAuthed(); err != nil {
+				return err
+			}
+			policy, err := optimizedPolicyForApp(a, cmd, optimized)
+			if err != nil {
 				return err
 			}
 
@@ -120,6 +126,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 				MaxMessages:         maxMessages,
 				MaxDBSizeBytes:      maxDBSize,
 				WarnNoLimits:        true,
+				Optimization:        policy,
 				WebhookURL:          webhookURL,
 				WebhookSecret:       webhookSecret,
 				WebhookAllowPrivate: webhookAllowPrivate,
@@ -157,5 +164,6 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&webhookEventsFlag, "webhook-events", string(appPkg.SyncWebhookEventMessage), "comma-separated event types to POST: message, receipt, chat_presence")
 	cmd.Flags().Int64Var(&storage.maxMessages, "max-messages", 0, "maximum total messages to keep in the local DB before sync stops (0 = unlimited, or WACLI_SYNC_MAX_MESSAGES)")
 	cmd.Flags().StringVar(&storage.maxDBSize, "max-db-size", "", "maximum wacli.db disk usage before sync stops, e.g. 500MB or 2GB (default: WACLI_SYNC_MAX_DB_SIZE or unlimited)")
+	addOptimizedFlags(cmd, &optimized)
 	return cmd
 }

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -37,3 +37,7 @@ wacli auth --download-media
 wacli auth status --json
 wacli auth logout
 ```
+
+For large accounts, `wacli auth --optimized` persists a bounded local index and
+asks WhatsApp for at most 30 days and 50 messages per chat during initial
+pairing. See [sync](sync.md#optimized-sync) for the retained-chat policy.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -95,3 +95,33 @@ wacli sync --follow --stale-threshold 2m --events 2>events.ndjson
 wacli sync --follow --webhook https://example.com/wacli --webhook-secret "$WACLI_WEBHOOK_SECRET"
 wacli sync --follow --webhook https://example.com/wacli --webhook-events message,receipt,chat_presence
 ```
+
+## Optimized sync
+
+Use `--optimized` for a bounded local index on large WhatsApp accounts. The
+policy is saved with the selected account and later `sync` runs enforce it
+automatically. Its defaults retain the 100 most active non-archived chats and
+the newest 50 messages in each, request 30 days of initial history while
+pairing, disable automatic media downloads, and skip call and Status records.
+
+```bash
+wacli auth --optimized
+wacli sync --follow
+```
+
+On an existing populated store, first activation prunes local data and needs an
+explicit confirmation:
+
+```bash
+wacli sync --optimized --confirm
+```
+
+This deletes indexed messages outside the retained set, all locally downloaded
+media files, and existing call/Status rows. It never deletes WhatsApp history
+from the primary phone.
+
+Use `--max-chats`, `--history-days`, and `--history-messages-per-chat` to tune
+the persisted policy. The history request settings only affect a fresh linked
+device, so logout and pair again to apply them to an existing WhatsApp session.
+`--download-media` cannot be combined with optimized sync, but explicit
+`wacli media download` commands remain available.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -125,6 +125,7 @@ type App struct {
 	manualFetchMu   sync.Mutex
 	manualFetches   map[string]int
 	heartbeatLast   atomic.Int64
+	optimization    store.SyncOptimizationPolicy
 }
 
 func New(opts Options) (*App, error) {

--- a/internal/app/sync.go
+++ b/internal/app/sync.go
@@ -74,6 +74,7 @@ type SyncOptions struct {
 	MaxMessages         int64         // 0 = unlimited
 	MaxDBSizeBytes      int64         // 0 = unlimited
 	WarnNoLimits        bool
+	Optimization        *store.SyncOptimizationPolicy
 	WebhookURL          string
 	WebhookSecret       string
 	WebhookAllowPrivate bool
@@ -92,6 +93,28 @@ func (a *App) Sync(ctx context.Context, opts SyncOptions) (SyncResult, error) {
 	if opts.Mode == "" {
 		opts.Mode = SyncModeFollow
 	}
+	policy := store.SyncOptimizationPolicy{}
+	if opts.Optimization != nil {
+		policy = *opts.Optimization
+		if err := a.db.SetSyncOptimizationPolicy(policy); err != nil {
+			return SyncResult{}, fmt.Errorf("save optimized sync policy: %w", err)
+		}
+	} else {
+		var err error
+		policy, err = a.db.SyncOptimizationPolicy()
+		if err != nil {
+			return SyncResult{}, fmt.Errorf("load optimized sync policy: %w", err)
+		}
+	}
+	if policy.Enabled {
+		if opts.DownloadMedia {
+			return SyncResult{}, fmt.Errorf("--download-media cannot be used while optimized sync is enabled")
+		}
+		if _, err := a.db.ApplySyncOptimizationRetention(policy); err != nil {
+			return SyncResult{}, fmt.Errorf("apply optimized retention: %w", err)
+		}
+	}
+	a.optimization = policy
 	if opts.PresenceMode == "" {
 		opts.PresenceMode = SyncPresenceModeNormal
 	}
@@ -583,6 +606,9 @@ func (a *App) storeParsedMessage(ctx context.Context, pm wa.ParsedMessage) error
 }
 
 func (a *App) storeParsedCallEvent(ctx context.Context, call wa.ParsedCallEvent, chatName, senderName string) error {
+	if a.optimization.Enabled && !a.optimization.PersistCalls {
+		return nil
+	}
 	call.Chat = a.canonicalStoreJID(ctx, call.Chat)
 	chatJID := canonicalJIDString(call.Chat)
 	if chatJID == "" {

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -393,6 +393,9 @@ func (a *App) handleDeleteForMeEvent(ctx context.Context, evt *events.DeleteForM
 }
 
 func (a *App) handleLiveCallEvent(ctx context.Context, evt interface{}) error {
+	if a.optimization.Enabled && !a.optimization.PersistCalls {
+		return nil
+	}
 	self := a.linkedLiveCallIdentity()
 	var alternateSelf []types.JID
 	if _, ok := evt.(*events.AppState); ok {
@@ -533,6 +536,14 @@ func (a *App) handleLiveSyncMessage(ctx context.Context, opts SyncOptions, v *ev
 	if pm.ReactionToID != "" && pm.ReactionEmoji == "" && v.Message != nil && v.Message.GetEncReactionMessage() != nil {
 		a.decryptEncryptedReaction(ctx, &pm, v)
 	}
+	allowed, err := a.optimizationAllowsMessage(ctx, pm)
+	if err != nil {
+		a.emitWarning("optimized_sync_policy_failed", fmt.Sprintf("warning: apply optimized sync policy: %v", err), map[string]any{"error": err.Error()})
+		return
+	}
+	if !allowed {
+		return
+	}
 	incrementUnread := a.shouldIncrementLiveUnread(ctx, pm)
 	if err := a.storeParsedMessageForSync(ctx, pm, limits...); err == nil {
 		if incrementUnread {
@@ -578,6 +589,27 @@ func historySyncNotificationFromMessage(v *events.Message) *waE2E.HistorySyncNot
 		return nil
 	}
 	return v.Message.GetProtocolMessage().GetHistorySyncNotification()
+}
+
+func (a *App) optimizationAllowsMessage(ctx context.Context, pm wa.ParsedMessage) (bool, error) {
+	p := a.optimization
+	if !p.Enabled {
+		return true, nil
+	}
+	if pm.Chat == types.StatusBroadcastJID {
+		return p.PersistStatuses, nil
+	}
+	chat := a.canonicalStoreJID(ctx, pm.Chat)
+	if chat.IsEmpty() {
+		return false, nil
+	}
+	if err := a.db.UpsertChat(chat.String(), chatKind(chat), "", pm.Timestamp); err != nil {
+		return false, err
+	}
+	if _, err := a.db.ApplySyncOptimizationRetention(p); err != nil {
+		return false, err
+	}
+	return a.db.ChatIsInSyncOptimizationSet(chat.String(), p)
 }
 
 const maxHistoryUnhandledPayloadWarnings = 10
@@ -630,7 +662,26 @@ func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events
 	var unhandledWarnings historyUnhandledPayloadWarnings
 	defer unhandledWarnings.flush(a)
 	a.emitOrPrint("history_sync", map[string]any{"conversations": len(v.Data.Conversations)}, "\nProcessing history sync (%d conversations)...\n", len(v.Data.Conversations))
-	a.storeHistoryCallLogRecords(ctx, v, lastEvent)
+	if !a.optimization.Enabled || a.optimization.PersistCalls {
+		a.storeHistoryCallLogRecords(ctx, v, lastEvent)
+	}
+	if a.optimization.Enabled {
+		for _, conv := range v.Data.Conversations {
+			chatID := strings.TrimSpace(conv.GetID())
+			jid, err := types.ParseJID(chatID)
+			if chatID == "" || err != nil || jid.IsEmpty() {
+				continue
+			}
+			activity := int64(conv.GetLastMsgTimestamp())
+			if ts := int64(conv.GetConversationTimestamp()); ts > activity {
+				activity = ts
+			}
+			_ = a.db.UpsertHistoryChat(canonicalJIDString(a.canonicalStoreJID(ctx, jid)), chatKind(jid), conv.GetName(), time.Unix(activity, 0).UTC(), conv.Archived)
+		}
+		if _, err := a.db.ApplySyncOptimizationRetention(a.optimization); err != nil {
+			a.emitWarning("optimized_retention_failed", fmt.Sprintf("warning: apply optimized retention: %v", err), map[string]any{"error": err.Error()})
+		}
+	}
 	for _, conv := range v.Data.Conversations {
 		lastEvent.Store(nowUTC().UnixNano())
 		chatID := strings.TrimSpace(conv.GetID())
@@ -638,6 +689,16 @@ func (a *App) handleHistorySync(ctx context.Context, opts SyncOptions, v *events
 			continue
 		}
 		a.storeHistoryUnreadCount(ctx, chatID, conv)
+		if a.optimization.Enabled {
+			jid, err := types.ParseJID(chatID)
+			if err != nil || jid.IsEmpty() {
+				continue
+			}
+			allowed, err := a.db.ChatIsInSyncOptimizationSet(canonicalJIDString(a.canonicalStoreJID(ctx, jid)), a.optimization)
+			if err != nil || !allowed {
+				continue
+			}
+		}
 		var pendingPolls []historyPollSideEffect
 		for _, m := range conv.Messages {
 			lastEvent.Store(nowUTC().UnixNano())
@@ -777,10 +838,19 @@ func (a *App) emitSyncProgress(total int64) {
 }
 
 func (a *App) storeParsedMessageForSync(ctx context.Context, pm wa.ParsedMessage, limits ...*syncStorageLimits) error {
+	var err error
 	if len(limits) > 0 && limits[0] != nil {
-		return limits[0].StoreParsedMessage(ctx, pm)
+		err = limits[0].StoreParsedMessage(ctx, pm)
+	} else {
+		err = a.storeParsedMessage(ctx, pm)
 	}
-	return a.storeParsedMessage(ctx, pm)
+	if err != nil {
+		return err
+	}
+	if a.optimization.Enabled {
+		_, err = a.db.ApplySyncOptimizationRetention(a.optimization)
+	}
+	return err
 }
 
 func (a *App) decryptEncryptedReaction(ctx context.Context, pm *wa.ParsedMessage, msg *events.Message) {

--- a/internal/store/chats.go
+++ b/internal/store/chats.go
@@ -41,6 +41,176 @@ func (d *DB) UpsertChatMetadata(jid, kind, name string) error {
 	})
 }
 
+// UpsertHistoryChat records lightweight conversation state even when its
+// messages are intentionally excluded from the local index.
+func (d *DB) UpsertHistoryChat(jid, kind, name string, lastTS time.Time, archived *bool) error {
+	if strings.TrimSpace(kind) == "" {
+		kind = "unknown"
+	}
+	archivedValue := any(nil)
+	if archived != nil {
+		archivedValue = boolToInt(*archived)
+	}
+	_, err := d.sql.ExecContext(storeCtx(), `
+		INSERT INTO chats(jid,kind,name,last_message_ts,archived)
+		VALUES(?,?,?,?,COALESCE(?,0))
+		ON CONFLICT(jid) DO UPDATE SET
+		kind=excluded.kind,
+		name=CASE WHEN excluded.name IS NOT NULL AND excluded.name != '' THEN excluded.name ELSE chats.name END,
+		last_message_ts=MAX(COALESCE(chats.last_message_ts,0),COALESCE(excluded.last_message_ts,0)),
+		archived=COALESCE(?, chats.archived)`,
+		jid, kind, nullString(name), sqlNullInt64(unix(lastTS)), archivedValue, archivedValue)
+	return err
+}
+
+// ApplySyncOptimizationRetention prunes indexed payloads while keeping chat,
+// contact and group metadata available for recipient resolution.
+func (d *DB) ApplySyncOptimizationRetention(p SyncOptimizationPolicy) (int64, error) {
+	if !p.Enabled {
+		return 0, nil
+	}
+	if err := p.Validate(); err != nil {
+		return 0, err
+	}
+	q := `SELECT jid FROM chats`
+	if p.ExcludeArchived {
+		q += ` WHERE archived=0`
+	}
+	q += ` ORDER BY COALESCE(last_message_ts,0) DESC, jid ASC LIMIT ?`
+	rows, err := d.sql.QueryContext(storeCtx(), q, p.MaxChats)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	keep := make(map[string]struct{}, p.MaxChats)
+	for rows.Next() {
+		var jid string
+		if err := rows.Scan(&jid); err != nil {
+			return 0, err
+		}
+		keep[jid] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	indexed, err := d.sql.QueryContext(storeCtx(), `SELECT DISTINCT chat_jid FROM messages`)
+	if err != nil {
+		return 0, err
+	}
+	defer indexed.Close()
+	var pruned int64
+	for indexed.Next() {
+		var jid string
+		if err := indexed.Scan(&jid); err != nil {
+			return pruned, err
+		}
+		if _, ok := keep[jid]; !ok && p.PruneEvictedChats {
+			n, err := d.PruneIndexedChatData(jid)
+			if err != nil {
+				return pruned, err
+			}
+			pruned += n
+		}
+	}
+	if err := indexed.Err(); err != nil {
+		return pruned, err
+	}
+	for jid := range keep {
+		n, err := d.PruneChatMessagesToLimit(jid, p.MaxMessagesPerChat)
+		if err != nil {
+			return pruned, err
+		}
+		pruned += n
+	}
+	if !p.PersistCalls {
+		if _, err := d.sql.ExecContext(storeCtx(), `DELETE FROM call_events`); err != nil {
+			return pruned, err
+		}
+	}
+	if !p.PersistStatuses {
+		if _, err := d.sql.ExecContext(storeCtx(), `DELETE FROM status_messages`); err != nil {
+			return pruned, err
+		}
+	}
+	return pruned, nil
+}
+
+func (d *DB) ChatIsInSyncOptimizationSet(jid string, p SyncOptimizationPolicy) (bool, error) {
+	if !p.Enabled {
+		return true, nil
+	}
+	q := `SELECT jid FROM chats`
+	if p.ExcludeArchived {
+		q += ` WHERE archived=0`
+	}
+	q += ` ORDER BY COALESCE(last_message_ts,0) DESC, jid ASC LIMIT ?`
+	rows, err := d.sql.QueryContext(storeCtx(), q, p.MaxChats)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var candidate string
+		if err := rows.Scan(&candidate); err != nil {
+			return false, err
+		}
+		if candidate == jid {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+func (d *DB) PruneIndexedChatData(jid string) (int64, error) {
+	tx, err := d.sql.BeginTx(storeCtx(), nil)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+	if _, err = tx.Exec(`DELETE FROM poll_votes WHERE chat_jid=?`, jid); err != nil {
+		return 0, err
+	}
+	if _, err = tx.Exec(`DELETE FROM polls WHERE chat_jid=?`, jid); err != nil {
+		return 0, err
+	}
+	if _, err = tx.Exec(`DELETE FROM message_locations WHERE chat_jid=?`, jid); err != nil {
+		return 0, err
+	}
+	if _, err = tx.Exec(`DELETE FROM starred WHERE chat_jid=?`, jid); err != nil {
+		return 0, err
+	}
+	if _, err = tx.Exec(`DELETE FROM call_events WHERE chat_jid=?`, jid); err != nil {
+		return 0, err
+	}
+	res, err := tx.Exec(`DELETE FROM messages WHERE chat_jid=?`, jid)
+	if err != nil {
+		return 0, err
+	}
+	if err = tx.Commit(); err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+func (d *DB) PruneChatMessagesToLimit(jid string, limit int) (int64, error) {
+	if limit <= 0 {
+		return 0, fmt.Errorf("message limit must be positive")
+	}
+	res, err := d.sql.ExecContext(storeCtx(), `DELETE FROM messages WHERE chat_jid=? AND rowid NOT IN (SELECT rowid FROM messages WHERE chat_jid=? ORDER BY ts DESC,rowid DESC LIMIT ?)`, jid, jid, limit)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	// Remove records keyed to messages that were just evicted.
+	_, _ = d.sql.ExecContext(storeCtx(), `DELETE FROM message_locations WHERE chat_jid=? AND msg_id NOT IN (SELECT msg_id FROM messages WHERE chat_jid=?)`, jid, jid)
+	_, _ = d.sql.ExecContext(storeCtx(), `DELETE FROM starred WHERE chat_jid=? AND msg_id NOT IN (SELECT msg_id FROM messages WHERE chat_jid=?)`, jid, jid)
+	_, _ = d.sql.ExecContext(storeCtx(), `DELETE FROM polls WHERE chat_jid=? AND msg_id NOT IN (SELECT msg_id FROM messages WHERE chat_jid=?)`, jid, jid)
+	_, _ = d.sql.ExecContext(storeCtx(), `DELETE FROM poll_votes WHERE chat_jid=? AND poll_msg_id NOT IN (SELECT msg_id FROM messages WHERE chat_jid=?)`, jid, jid)
+	return n, nil
+}
+
 func (d *DB) ListChats(query string, limit int) ([]Chat, error) {
 	return d.ListChatsFiltered(ChatListFilter{Query: query, Limit: limit})
 }

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -101,6 +101,10 @@ func (d *DB) Close() error {
 	return d.sql.Close()
 }
 
+// Raw exposes no write helpers; it is used only by command-level diagnostics
+// that must count existing local data before an explicit destructive action.
+func (d *DB) Raw() *sql.DB { return d.sql }
+
 func (d *DB) init() error {
 	// Pragmas: keep consistent for writers/readers.
 	_, _ = d.sql.Exec("PRAGMA journal_mode=WAL;")

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -249,6 +249,41 @@ func (d *DB) MessageLocalMediaPaths(chatJID, msgID string) ([]string, error) {
 	return paths, rows.Err()
 }
 
+// AllLocalMediaPaths returns the distinct media files managed by this store.
+func (d *DB) AllLocalMediaPaths() ([]string, error) {
+	rows, err := d.sql.Query(`SELECT local_path FROM messages WHERE COALESCE(local_path,'') != '' UNION SELECT local_path FROM message_local_media_aliases WHERE COALESCE(local_path,'') != '' ORDER BY 1`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var paths []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, err
+		}
+		paths = append(paths, p)
+	}
+	return paths, rows.Err()
+}
+
+// ClearAllLocalMediaPaths forgets downloaded files after callers have removed
+// them from disk. It deliberately leaves remote media metadata searchable.
+func (d *DB) ClearAllLocalMediaPaths() error {
+	tx, err := d.sql.BeginTx(storeCtx(), nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(`UPDATE messages SET local_path=NULL, downloaded_at=NULL WHERE COALESCE(local_path,'') != ''`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DELETE FROM message_local_media_aliases`); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 func (d *DB) UpdateMessageText(chatJID, msgID, text string) error {
 	n, err := d.q.UpdateMessageText(storeCtx(), storedb.UpdateMessageTextParams{
 		Text:        nullString(text),

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -39,6 +39,28 @@ var schemaMigrations = []migration{
 	{version: 23, name: "app state recovery markers", up: migrateAppStateRecoveryMarkers},
 	{version: 24, name: "app state recovery intents", up: migrateAppStateRecoveryIntents},
 	{version: 25, name: "message locations", up: migrateMessageLocations},
+	{version: 26, name: "sync optimization policy", up: migrateSyncOptimizationPolicy},
+}
+
+func migrateSyncOptimizationPolicy(d *DB) error {
+	_, err := d.sql.Exec(`
+		CREATE TABLE IF NOT EXISTS sync_optimization_policy (
+			id INTEGER PRIMARY KEY CHECK (id = 1),
+			enabled INTEGER NOT NULL DEFAULT 0,
+			max_chats INTEGER NOT NULL DEFAULT 100,
+			exclude_archived INTEGER NOT NULL DEFAULT 1,
+			history_days INTEGER NOT NULL DEFAULT 30,
+			max_messages_per_chat INTEGER NOT NULL DEFAULT 50,
+			prune_evicted_chats INTEGER NOT NULL DEFAULT 1,
+			persist_calls INTEGER NOT NULL DEFAULT 0,
+			persist_statuses INTEGER NOT NULL DEFAULT 0,
+			updated_at INTEGER NOT NULL
+		);
+	`)
+	if err != nil {
+		return fmt.Errorf("create sync optimization policy table: %w", err)
+	}
+	return nil
 }
 
 func migrateMessageLocations(d *DB) error {

--- a/internal/store/sync_policy.go
+++ b/internal/store/sync_policy.go
@@ -1,0 +1,66 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// SyncOptimizationPolicy controls the bounded local index used by --optimized.
+// The policy is stored with the account rather than in global configuration so
+// named accounts can choose independent retention behaviour.
+type SyncOptimizationPolicy struct {
+	Enabled            bool
+	MaxChats           int
+	ExcludeArchived    bool
+	HistoryDays        int
+	MaxMessagesPerChat int
+	PruneEvictedChats  bool
+	PersistCalls       bool
+	PersistStatuses    bool
+}
+
+func DefaultSyncOptimizationPolicy() SyncOptimizationPolicy {
+	return SyncOptimizationPolicy{
+		Enabled: true, MaxChats: 100, ExcludeArchived: true, HistoryDays: 30,
+		MaxMessagesPerChat: 50, PruneEvictedChats: true,
+	}
+}
+
+func (p SyncOptimizationPolicy) Validate() error {
+	if !p.Enabled {
+		return nil
+	}
+	if p.MaxChats <= 0 || p.HistoryDays <= 0 || p.MaxMessagesPerChat <= 0 {
+		return fmt.Errorf("optimized limits must be positive")
+	}
+	return nil
+}
+
+func (d *DB) SyncOptimizationPolicy() (SyncOptimizationPolicy, error) {
+	row := d.sql.QueryRowContext(storeCtx(), `SELECT enabled,max_chats,exclude_archived,history_days,max_messages_per_chat,prune_evicted_chats,persist_calls,persist_statuses FROM sync_optimization_policy WHERE id=1`)
+	var p SyncOptimizationPolicy
+	var enabled, archived, prune, calls, statuses int
+	err := row.Scan(&enabled, &p.MaxChats, &archived, &p.HistoryDays, &p.MaxMessagesPerChat, &prune, &calls, &statuses)
+	if err == sql.ErrNoRows {
+		return SyncOptimizationPolicy{}, nil
+	}
+	if err != nil {
+		return SyncOptimizationPolicy{}, err
+	}
+	p.Enabled, p.ExcludeArchived, p.PruneEvictedChats = enabled != 0, archived != 0, prune != 0
+	p.PersistCalls, p.PersistStatuses = calls != 0, statuses != 0
+	return p, nil
+}
+
+func (d *DB) SetSyncOptimizationPolicy(p SyncOptimizationPolicy) error {
+	if err := p.Validate(); err != nil {
+		return err
+	}
+	_, err := d.sql.ExecContext(storeCtx(), `
+		INSERT INTO sync_optimization_policy(id,enabled,max_chats,exclude_archived,history_days,max_messages_per_chat,prune_evicted_chats,persist_calls,persist_statuses,updated_at)
+		VALUES(1,?,?,?,?,?,?,?,?,?)
+		ON CONFLICT(id) DO UPDATE SET enabled=excluded.enabled,max_chats=excluded.max_chats,exclude_archived=excluded.exclude_archived,history_days=excluded.history_days,max_messages_per_chat=excluded.max_messages_per_chat,prune_evicted_chats=excluded.prune_evicted_chats,persist_calls=excluded.persist_calls,persist_statuses=excluded.persist_statuses,updated_at=excluded.updated_at`,
+		boolToInt(p.Enabled), p.MaxChats, boolToInt(p.ExcludeArchived), p.HistoryDays, p.MaxMessagesPerChat, boolToInt(p.PruneEvictedChats), boolToInt(p.PersistCalls), boolToInt(p.PersistStatuses), time.Now().UTC().Unix())
+	return err
+}

--- a/internal/store/sync_policy_test.go
+++ b/internal/store/sync_policy_test.go
@@ -1,0 +1,46 @@
+package store
+
+import "testing"
+
+func TestSyncOptimizationPolicyRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+	if got, err := db.SyncOptimizationPolicy(); err != nil || got.Enabled {
+		t.Fatalf("default policy = %+v, %v", got, err)
+	}
+	want := DefaultSyncOptimizationPolicy()
+	want.MaxChats = 7
+	want.MaxMessagesPerChat = 3
+	if err := db.SetSyncOptimizationPolicy(want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := db.SyncOptimizationPolicy()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("policy = %+v, want %+v", got, want)
+	}
+}
+
+func TestSyncOptimizationSetExcludesArchived(t *testing.T) {
+	db := openTestDB(t)
+	p := DefaultSyncOptimizationPolicy()
+	p.MaxChats = 1
+	if err := db.UpsertChat("old@s.whatsapp.net", "dm", "old", nowUTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertChat("new@s.whatsapp.net", "dm", "new", nowUTC().AddDate(0, 0, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetChatArchived("new@s.whatsapp.net", true); err != nil {
+		t.Fatal(err)
+	}
+	ok, err := db.ChatIsInSyncOptimizationSet("old@s.whatsapp.net", p)
+	if err != nil || !ok {
+		t.Fatalf("old chat retained = %t, %v", ok, err)
+	}
+	ok, err = db.ChatIsInSyncOptimizationSet("new@s.whatsapp.net", p)
+	if err != nil || ok {
+		t.Fatalf("archived chat retained = %t, %v", ok, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a persisted `--optimized` sync policy for bounded large-account indexes
- retain the 100 most-active non-archived chats and 50 newest messages per chat
- request reduced initial history during pairing and disable automatic media, call, and Status persistence
- require `--confirm` before first cleanup of a populated local store

## Verification
- `pnpm test`
- `pnpm build`
- `pnpm format:check`
- `pnpm lint`
- `git diff --check`

## Notes
Existing local data is pruned only after explicit optimized activation; no WhatsApp phone history is changed.