### PR TITLE
fix(site): harden documentation rendering

### DIFF
--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { css, faviconSvg, js, socialCardSvg, themeBootstrapScript, themeToggleMarkup } from "./docs-site-assets.mjs";
-import { escapeAttr, escapeHtml, markdownToHtml, tocFromHtml, validateLinks } from "./docs-site-render.mjs";
+import { escapeAttr, escapeHtml, renderMarkdown, tocFromHeadings, validateLinks } from "./docs-site-render.mjs";
 
 const root = process.cwd();
 const docsDir = path.join(root, "docs");
@@ -62,8 +62,8 @@ for (const section of nav) for (const page of section.pages) sectionByRel.set(pa
 const orderedPages = nav.flatMap((s) => s.pages);
 
 for (const page of pages) {
-  const html = markdownToHtml(page.markdown, page.rel, rewriteHref);
-  const toc = tocFromHtml(html);
+  const { html, headings } = renderMarkdown(page.markdown, page.rel, rewriteHref);
+  const toc = tocFromHeadings(headings);
   const idx = orderedPages.findIndex((p) => p.rel === page.rel);
   const prev = idx > 0 ? orderedPages[idx - 1] : null;
   const next = idx >= 0 && idx < orderedPages.length - 1 ? orderedPages[idx + 1] : null;

--- a/scripts/docs-site-render.mjs
+++ b/scripts/docs-site-render.mjs
@@ -3,18 +3,23 @@ import path from "node:path";
 
 import { highlight } from "./docs-site-highlight.mjs";
 
-export function markdownToHtml(markdown, currentRel, rewriteHref) {
+export function renderMarkdown(markdown, currentRel, rewriteHref) {
+  const state = { headings: [], slugs: new Map() };
+  const html = renderMarkdownInto(markdown, currentRel, rewriteHref, state);
+  return { html, headings: state.headings };
+}
+
+function renderMarkdownInto(markdown, currentRel, rewriteHref, state) {
   const lines = markdown.replace(/\r\n/g, "\n").split("\n");
   const html = [];
   let paragraph = [];
   let list = null;
   let fence = null;
   let blockquote = [];
-  const slugs = new Map();
 
   const flushParagraph = () => {
     if (!paragraph.length) return;
-    html.push(`<p>${inline(paragraph.join(" "), currentRel, rewriteHref)}</p>`);
+    html.push(`<p>${inline(paragraph.join(" "), currentRel, rewriteHref).html}</p>`);
     paragraph = [];
   };
   const closeList = () => {
@@ -24,7 +29,7 @@ export function markdownToHtml(markdown, currentRel, rewriteHref) {
   };
   const flushBlockquote = () => {
     if (!blockquote.length) return;
-    const inner = markdownToHtml(blockquote.join("\n"), currentRel, rewriteHref);
+    const inner = renderMarkdownInto(blockquote.join("\n"), currentRel, rewriteHref, state);
     html.push(`<blockquote>${inner}</blockquote>`);
     blockquote = [];
   };
@@ -72,12 +77,15 @@ export function markdownToHtml(markdown, currentRel, rewriteHref) {
       closeList();
       const level = heading[1].length;
       const text = heading[2].trim();
-      const id = uniqueSlug(slugs, text);
+      const id = uniqueSlug(state.slugs, text);
       const inner = inline(text, currentRel, rewriteHref);
+      if (level === 2 || level === 3) {
+        state.headings.push({ level, id, label: inner.text });
+      }
       if (level === 1) {
-        html.push(`<h1 id="${id}">${inner}</h1>`);
+        html.push(`<h1 id="${id}">${inner.html}</h1>`);
       } else {
-        html.push(`<h${level} id="${id}"><a class="anchor" href="#${id}" aria-label="Anchor link">#</a>${inner}</h${level}>`);
+        html.push(`<h${level} id="${id}"><a class="anchor" href="#${id}" aria-label="Anchor link">#</a>${inner.html}</h${level}>`);
       }
       continue;
     }
@@ -96,8 +104,8 @@ export function markdownToHtml(markdown, currentRel, rewriteHref) {
         i += 1;
         rows.push(splitRow(lines[i]));
       }
-      const th = header.map((c, idx) => `<th${aligns[idx] ? ` style="text-align:${aligns[idx]}"` : ""}>${inline(c, currentRel, rewriteHref)}</th>`).join("");
-      const tb = rows.map((r) => `<tr>${r.map((c, idx) => `<td${aligns[idx] ? ` style="text-align:${aligns[idx]}"` : ""}>${inline(c, currentRel, rewriteHref)}</td>`).join("")}</tr>`).join("");
+      const th = header.map((c, idx) => `<th${aligns[idx] ? ` style="text-align:${aligns[idx]}"` : ""}>${inline(c, currentRel, rewriteHref).html}</th>`).join("");
+      const tb = rows.map((r) => `<tr>${r.map((c, idx) => `<td${aligns[idx] ? ` style="text-align:${aligns[idx]}"` : ""}>${inline(c, currentRel, rewriteHref).html}</td>`).join("")}</tr>`).join("");
       html.push(`<table><thead><tr>${th}</tr></thead><tbody>${tb}</tbody></table>`);
       continue;
     }
@@ -111,7 +119,7 @@ export function markdownToHtml(markdown, currentRel, rewriteHref) {
         list = tag;
         html.push(`<${tag}>`);
       }
-      html.push(`<li>${inline((bullet || numbered)[1], currentRel, rewriteHref)}</li>`);
+      html.push(`<li>${inline((bullet || numbered)[1], currentRel, rewriteHref).html}</li>`);
       continue;
     }
     paragraph.push(line.trim());
@@ -122,20 +130,10 @@ export function markdownToHtml(markdown, currentRel, rewriteHref) {
   return html.join("\n");
 }
 
-export function tocFromHtml(html) {
-  const items = [];
-  const re = /<h([23]) id="([^"]+)">([\s\S]*?)<\/h[23]>/g;
-  let m;
-  while ((m = re.exec(html))) {
-    const text = m[3]
-      .replace(/<a class="anchor"[^>]*>.*?<\/a>/, "")
-      .replace(/<[^>]+>/g, "")
-      .trim();
-    items.push({ level: Number(m[1]), id: m[2], text });
-  }
-  if (items.length < 2) return "";
-  return `<nav class="toc" aria-label="On this page"><h2>On this page</h2>${items
-    .map((i) => `<a class="toc-l${i.level}" href="#${i.id}">${escapeHtml(i.text)}</a>`)
+export function tocFromHeadings(headings) {
+  if (headings.length < 2) return "";
+  return `<nav class="toc" aria-label="On this page"><h2>On this page</h2>${headings
+    .map((heading) => `<a class="toc-l${heading.level}" href="#${heading.id}">${escapeHtml(heading.label)}</a>`)
     .join("")}</nav>`;
 }
 
@@ -183,20 +181,84 @@ export function escapeAttr(value) {
 }
 
 function inline(text, currentRel, rewriteHref) {
-  const stash = [];
-  let out = text.replace(/`([^`]+)`/g, (_, code) => {
-    stash.push(`<code>${escapeHtml(code)}</code>`);
-    return `\u0000${stash.length - 1}\u0000`;
+  const tokens = [];
+  const stash = (token) => {
+    tokens.push(token);
+    return `\u0000${tokens.length - 1}\u0000`;
+  };
+  let value = text.replace(/`([^`]+)`/g, (_, code) => {
+    return stash({ kind: "code", value: code });
   });
-  out = escapeHtml(out)
-    .replace(/&lt;br&gt;/g, "<br>")
-    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
-    .replace(/(^|[^*])\*([^*\s][^*]*?)\*(?!\*)/g, "$1<em>$2</em>")
-    .replace(/(^|[^_])_([^_\s][^_]*?)_(?!_)/g, "$1<em>$2</em>")
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, label, href) => `<a href="${escapeAttr(rewriteHref(href, currentRel))}">${sanitizeLinkLabel(label)}</a>`)
-    .replace(/&lt;(https?:\/\/[^\s<>]+)&gt;/g, '<a href="$1">$1</a>');
-  out = out.replace(/\\\|/g, "|");
-  return out.replace(/\u0000(\d+)\u0000/g, (_, i) => stash[Number(i)]);
+  value = tokenizeInline(escapeHtml(value));
+  return renderInlineValue(value, tokens, false);
+
+  function tokenizeInline(escaped) {
+    return escaped
+    .replace(/&lt;br&gt;/g, () => stash({ kind: "break" }))
+    .replace(/\*\*([^*]+)\*\*/g, (_, inner) => stash({ kind: "strong", value: tokenizeInline(inner) }))
+    .replace(/(^|[^*])\*([^*\s][^*]*?)\*(?!\*)/g, (_, prefix, inner) => `${prefix}${stash({ kind: "em", value: tokenizeInline(inner) })}`)
+    .replace(/(^|[^_])_([^_\s][^_]*?)_(?!_)/g, (_, prefix, inner) => `${prefix}${stash({ kind: "em", value: tokenizeInline(inner) })}`)
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, label, href) => {
+      return stash({ kind: "link", value: tokenizeInline(label), href: rewriteHref(href, currentRel) });
+    })
+    .replace(/&lt;(https?:\/\/[^\s<>]+)&gt;/g, (_, href) => {
+      return stash({ kind: "autolink", href });
+    })
+    .replace(/\\\|/g, "|");
+  }
+}
+
+function renderInlineValue(value, tokens, linkLabel) {
+  const marker = /\u0000(\d+)\u0000/g;
+  let html = "";
+  let text = "";
+  let offset = 0;
+  for (const match of value.matchAll(marker)) {
+    const escaped = value.slice(offset, match.index);
+    html += escaped;
+    text += decodeEscapedText(escaped);
+    const rendered = renderInlineToken(tokens[Number(match[1])], tokens, linkLabel);
+    html += rendered.html;
+    text += rendered.text;
+    offset = match.index + match[0].length;
+  }
+  const escaped = value.slice(offset);
+  return {
+    html: html + escaped,
+    text: text + decodeEscapedText(escaped),
+  };
+}
+
+function renderInlineToken(token, tokens, linkLabel) {
+  if (token.kind === "code") {
+    return { html: `<code>${escapeHtml(token.value)}</code>`, text: token.value };
+  }
+  if (token.kind === "break") {
+    return linkLabel ? { html: "&lt;br&gt;", text: "<br>" } : { html: "<br>", text: "" };
+  }
+  if (token.kind === "autolink") {
+    return {
+      html: `<a href="${token.href}">${token.href}</a>`,
+      text: decodeEscapedText(token.href),
+    };
+  }
+  const inner = renderInlineValue(token.value, tokens, token.kind === "link" || linkLabel);
+  if (token.kind === "strong") {
+    return { html: `<strong>${inner.html}</strong>`, text: inner.text };
+  }
+  if (token.kind === "em") {
+    return { html: `<em>${inner.html}</em>`, text: inner.text };
+  }
+  return {
+    html: `<a href="${escapeAttr(token.href)}">${inner.html}</a>`,
+    text: inner.text,
+  };
+}
+
+function decodeEscapedText(value) {
+  return value.replace(/&(amp|lt|gt|quot|#39);/g, (entity) => {
+    return ({ "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&#39;": "'" })[entity];
+  });
 }
 
 function splitRow(line) {
@@ -236,15 +298,6 @@ function uniqueSlug(slugs, text) {
   const count = (slugs.get(base) || 0) + 1;
   slugs.set(base, count);
   return count === 1 ? base : `${base}-${count}`;
-}
-
-function sanitizeLinkLabel(label) {
-  return label.replace(/<\/?(?:strong|em)>|[<>]/g, (match) => {
-    if (match === "<strong>" || match === "</strong>" || match === "<em>" || match === "</em>") {
-      return match;
-    }
-    return match === "<" ? "&lt;" : "&gt;";
-  });
 }
 
 function allHtml(dir) {

--- a/scripts/docs-site-render.test.mjs
+++ b/scripts/docs-site-render.test.mjs
@@ -1,23 +1,112 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 
-import { markdownToHtml, tocFromHtml } from "./docs-site-render.mjs";
+import {
+  renderMarkdown,
+  tocFromHeadings,
+} from "./docs-site-render.mjs";
 
 const keepHref = (href) => href;
 
-test("markdownToHtml escapes raw HTML inside link labels", () => {
-  const html = markdownToHtml("[<br>](https://example.com)\n[<img src=x onerror=alert(1)>](https://example.com)", "index.md", keepHref);
+test("renderMarkdown escapes raw HTML inside link labels", () => {
+  const { html } = renderMarkdown("[<br>](https://example.com)\n[<img src=x onerror=alert(1)>](https://example.com)", "index.md", keepHref);
 
   assert.match(html, /<a href="https:\/\/example\.com">&lt;br&gt;<\/a>/);
   assert.doesNotMatch(html, /<a href="https:\/\/example\.com"><br><\/a>/);
   assert.doesNotMatch(html, /<img\b/);
 });
 
-test("markdownToHtml gives duplicate headings stable unique ids", () => {
-  const html = markdownToHtml("## Examples\n\n## Examples\n\n### Examples", "index.md", keepHref);
+test("renderMarkdown gives duplicate headings stable unique ids", () => {
+  const { html } = renderMarkdown("## Examples\n\n## Examples\n\n### Examples", "index.md", keepHref);
 
   assert.match(html, /<h2 id="examples">/);
   assert.match(html, /<h2 id="examples-2">/);
   assert.match(html, /<h3 id="examples-3">/);
-  assert.match(tocFromHtml(html), /href="#examples-2"/);
+});
+
+test("renderMarkdown preserves links nested inside heading emphasis", () => {
+  const { html, headings } = renderMarkdown(
+    "## **[the docs](https://example.com)** and *<https://example.com>*",
+    "index.md",
+    keepHref,
+  );
+
+  assert.match(html, /<strong><a href="https:\/\/example\.com">the docs<\/a><\/strong>/);
+  assert.match(html, /<em><a href="https:\/\/example\.com">https:\/\/example\.com<\/a><\/em>/);
+  assert.equal(headings[0].label, "the docs and https://example.com");
+});
+
+test("renderMarkdown builds safe TOC labels from parser-owned heading facts", () => {
+  const markdown = [
+    "## AT&T &amp; with **strong**, *emphasis*, and `code`",
+    "",
+    "> ### Read [**the docs**](https://example.com) or <https://example.com>",
+    ">",
+    "> ## AT&T &amp; with **strong**, *emphasis*, and `code`",
+    "",
+    '### [<img src=x onerror=alert(1)>](https://example.com) <scr<script>ipt>alert("toc")</scr<script>ipt>',
+  ].join("\n");
+  const { html, headings } = renderMarkdown(markdown, "index.md", keepHref);
+  const toc = tocFromHeadings(headings);
+
+  assert.deepEqual(headings, [
+    {
+      level: 2,
+      id: "at-t-amp-with-strong-emphasis-and-code",
+      label: "AT&T &amp; with strong, emphasis, and code",
+    },
+    {
+      level: 3,
+      id: "read-the-docs-https-example-com-or-https-example-com",
+      label: "Read the docs or https://example.com",
+    },
+    {
+      level: 2,
+      id: "at-t-amp-with-strong-emphasis-and-code-2",
+      label: "AT&T &amp; with strong, emphasis, and code",
+    },
+    {
+      level: 3,
+      id: "img-src-x-onerror-alert-1-https-example-com-scr-script-ipt-alert-toc-scr-script-ipt",
+      label: '<img src=x onerror=alert(1)> <scr<script>ipt>alert("toc")</scr<script>ipt>',
+    },
+  ]);
+  assert.match(html, /<blockquote><h3 id="read-the-docs-https-example-com-or-https-example-com">/);
+  assert.match(html, /<h2 id="at-t-amp-with-strong-emphasis-and-code-2">/);
+  assert.match(toc, />AT&amp;T &amp;amp; with strong, emphasis, and code<\/a>/);
+  assert.match(toc, />&lt;img src=x onerror=alert\(1\)&gt; &lt;scr&lt;script&gt;ipt&gt;alert\(&quot;toc&quot;\)&lt;\/scr&lt;script&gt;ipt&gt;<\/a>/);
+  assert.doesNotMatch(toc, /AT&amp;amp;T/);
+  assert.equal(toc.includes("<img"), false);
+  assert.equal(toc.includes("<script>"), false);
+});
+
+test("tocFromHeadings omits zero or one heading", () => {
+  assert.equal(tocFromHeadings([]), "");
+  assert.equal(tocFromHeadings([{ level: 2, id: "only", label: "Only" }]), "");
+});
+
+test("docs site build renders structured heading facts into the generated page", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "wacli-docs-site-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.mkdirSync(path.join(root, "docs"));
+  fs.writeFileSync(path.join(root, "docs", "index.md"), "# Home\n");
+  fs.writeFileSync(
+    path.join(root, "docs", "install.md"),
+    "# Install\n\n## AT&T **bold**\n\n### [<img onerror=alert(1)>](https://example.com)\n",
+  );
+  fs.writeFileSync(path.join(root, "docs", "quickstart.md"), "# Quickstart\n");
+  const result = spawnSync(process.execPath, [path.resolve("scripts/build-docs-site.mjs")], {
+    cwd: root,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const page = fs.readFileSync(path.join(root, "dist", "docs-site", "install.html"), "utf8");
+  assert.match(page, /href="#at-t-bold">AT&amp;T bold<\/a>/);
+  assert.match(page, /href="#img-onerror-alert-1-https-example-com">&lt;img onerror=alert\(1\)&gt;<\/a>/);
+  assert.equal(page.includes("<img onerror="), false);
 });


### PR DESCRIPTION
## Summary

- stop deriving table-of-contents labels by stripping serialized HTML
- produce rendered HTML and visible heading text from one recursively tokenized inline structure
- preserve nested inline links, deterministic duplicate anchors, and current generated site output

## Root cause

The docs renderer rebuilt TOC labels by regex-stripping generated heading HTML. Crafted nested tag fragments could survive the incomplete multi-character sanitization, and ordinary entities were double-encoded.

The renderer now records structured H2/H3 facts while parsing Markdown. HTML and visible text are projected from the same inline tokens, and the TOC escapes the recorded text at its output boundary. No generated HTML is reparsed or sanitized to recover labels.

## Verification

- pre-fix hostile heading reproduction captured double-encoded entities and nested tag fragments
- `pnpm test:docs` (12 tests)
- `pnpm docs:site`
- generated `dist/docs-site` is byte-equivalent to `main`
- `git diff --check`
- Sol/high implementation review: clean, 0.95 confidence
- Sol/high test audit: clean, 0.91 confidence
- exact-head CI, Docker, release builds, and CodeQL: green
- exact-head CodeQL analyses: Actions 0, Go 0, JavaScript/TypeScript 0
- ClawSweeper exact-head review: correct at 0.87 confidence, security cleared, no findings or risks
- roleless AWS Crabbox: checksum-verified Go 1.26.6, format, lint, full tests, and build passed

Exact head: `616b3fe4c975069b2f970c0ac8608e369519b97b`

- CI: https://github.com/openclaw/wacli/actions/runs/33106940645
- CodeQL: https://github.com/openclaw/wacli/actions/runs/33106937171
- ClawSweeper: https://github.com/openclaw/clawsweeper/actions/runs/33106976591
- AWS Crabbox: https://crabbox.openclaw.ai/portal/runs/run_b5fc71fac226

## Scope

- production: `scripts/build-docs-site.mjs`, `scripts/docs-site-render.mjs`
- tests: `scripts/docs-site-render.test.mjs`
- production delta: +102/-49, net +53
- test delta: +95/-6, net +89
- dependency/generated delta: 0
- no dependency or generated-file changes
- excluded release-owned `scripts/release-local.mjs` is untouched

CodeQL alert: https://github.com/openclaw/wacli/security/code-scanning/2
