### PR TITLE
fix(history): retry an unanswered backfill anchor once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- History: retry an unanswered backfill anchor once with the next local message, report both anchors, and keep retries bounded without deleting history or filtering message IDs. (#371 - thanks @Entretoize)
+
 ### Chore
 
 - Dependencies: update Go modules, pnpm, CI actions, GoReleaser, and Docker images; require Go 1.27.0 and align local, CI, and release toolchain checks.

--- a/cmd/wacli/history.go
+++ b/cmd/wacli/history.go
@@ -180,7 +180,7 @@ func newHistoryBackfillCmd(flags *rootFlags) *cobra.Command {
 
 	cmd.Flags().StringVar(&chat, "chat", "", "chat JID")
 	cmd.Flags().IntVar(&count, "count", app.DefaultBackfillCount, "number of messages to request per on-demand sync")
-	cmd.Flags().IntVar(&requests, "requests", app.DefaultBackfillRequests, "number of on-demand requests to attempt")
+	cmd.Flags().IntVar(&requests, "requests", app.DefaultBackfillRequests, "number of history batches to request (each may retry once after a timeout)")
 	cmd.Flags().DurationVar(&wait, "wait", 60*time.Second, "time to wait for an on-demand response per request")
 	cmd.Flags().DurationVar(&idleExit, "idle-exit", 5*time.Second, "exit after being idle (after backfill requests)")
 	return cmd

--- a/docs/history.md
+++ b/docs/history.md
@@ -22,11 +22,13 @@ wacli history backfill --chat JID [--count 50] [--requests N] [--wait 1m] [--idl
 ## Limits
 
 - `--count` defaults to 50 and must be at most 500.
-- `--requests` defaults to 1 and must be at most 100.
+- `--requests` defaults to 1 and must be at most 100. Each requested batch may make one extra attempt after a timeout.
 - Requests are per chat.
-- The anchor is the oldest locally stored message in that chat.
+- The anchor starts at the oldest locally stored message in that chat. If the phone does not answer within `--wait`, backfill retries once using the next chronological local message (timestamp, then row ID). No message IDs or content types are filtered out, and no local rows are deleted.
+- Each attempt gets its own `--wait`; a batch can therefore wait up to twice that duration for responses. If there is no next anchor, or the retry also times out, backfill stops with an error naming the unanswered anchor. Transport errors and cancellation are not retried.
+- A successful retry must add history older than the original local anchor to continue to another batch. Returning only already-stored messages stops backfill normally.
 - Automatic initial history-sync blob downloads are disabled during backfill; only on-demand responses are processed.
-- `--events` emits NDJSON request/response/stop lifecycle events on stderr.
+- `--events` emits NDJSON request/response/stop lifecycle events on stderr. Requests include `anchor_msg_id`, and a `warning` with code `backfill_anchor_retry` identifies the unanswered anchor and its replacement. Human output reports the same retry on stderr. The result's request count includes retry attempts.
 
 ## Examples
 

--- a/internal/app/backfill.go
+++ b/internal/app/backfill.go
@@ -3,12 +3,14 @@ package app
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/openclaw/wacli/internal/store"
 	"go.mau.fi/whatsmeow/proto/waE2E"
 	"go.mau.fi/whatsmeow/proto/waHistorySync"
 	"go.mau.fi/whatsmeow/types"
@@ -132,6 +134,48 @@ func (a *App) BackfillHistory(ctx context.Context, opts BackfillOptions) (Backfi
 
 	var requestsSent int
 	var responsesSeen int
+	errResponseTimeout := errors.New("timed out waiting for on-demand history sync response")
+	request := func(ctx context.Context, anchor store.MessageInfo) (onDemandResponse, error) {
+		if err := ctx.Err(); err != nil {
+			return onDemandResponse{}, err
+		}
+		ch := make(chan onDemandResponse, 4)
+		mu.Lock()
+		waitCh = ch
+		mu.Unlock()
+		defer func() {
+			mu.Lock()
+			waitCh = nil
+			mu.Unlock()
+		}()
+
+		requestsSent++
+		a.emitOrPrint("backfill_requesting", map[string]any{
+			"chat_jid":      chatStr,
+			"count":         opts.Count,
+			"request":       requestsSent,
+			"anchor_msg_id": anchor.MsgID,
+		}, "Requesting %d older messages for %s...\n", opts.Count, chatStr)
+		reqInfo := types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, IsFromMe: anchor.FromMe},
+			ID:            types.MessageID(anchor.MsgID),
+			Timestamp:     anchor.Timestamp,
+		}
+		if _, err := a.wa.RequestHistorySyncOnDemand(ctx, reqInfo, opts.Count); err != nil {
+			return onDemandResponse{}, err
+		}
+		timer := time.NewTimer(opts.WaitPerRequest)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return onDemandResponse{}, ctx.Err()
+		case resp := <-ch:
+			responsesSeen++
+			return resp, nil
+		case <-timer.C:
+			return onDemandResponse{}, fmt.Errorf("%w (anchor %s)", errResponseTimeout, anchor.MsgID)
+		}
+	}
 
 	syncRes, err := a.Sync(ctx, SyncOptions{
 		Mode:     SyncModeOnce,
@@ -147,45 +191,22 @@ func (a *App) BackfillHistory(ctx context.Context, opts BackfillOptions) (Backfi
 					return err
 				}
 
-				reqInfo := types.MessageInfo{
-					MessageSource: types.MessageSource{
-						Chat:     chat,
-						IsFromMe: oldest.FromMe,
-					},
-					ID:        types.MessageID(oldest.MsgID),
-					Timestamp: oldest.Timestamp,
+				resp, err := request(ctx, oldest)
+				if errors.Is(err, errResponseTimeout) && ctx.Err() == nil {
+					next, nextErr := a.db.GetNextMessageInfo(chatStr, oldest.MsgID)
+					if nextErr != nil && !errors.Is(nextErr, sql.ErrNoRows) {
+						return nextErr
+					}
+					if nextErr == nil {
+						a.emitWarning("backfill_anchor_retry",
+							fmt.Sprintf("warning: no history response for anchor %s; retrying once with next local anchor %s", oldest.MsgID, next.MsgID),
+							map[string]any{"chat_jid": chatStr, "anchor_msg_id": oldest.MsgID, "retry_anchor_msg_id": next.MsgID})
+						resp, err = request(ctx, next)
+					}
 				}
-
-				ch := make(chan onDemandResponse, 4)
-				mu.Lock()
-				waitCh = ch
-				mu.Unlock()
-
-				requestsSent++
-				a.emitOrPrint("backfill_requesting", map[string]any{
-					"chat_jid": chatStr,
-					"count":    opts.Count,
-					"request":  requestsSent,
-				}, "Requesting %d older messages for %s...\n", opts.Count, chatStr)
-				if _, err := a.wa.RequestHistorySyncOnDemand(ctx, reqInfo, opts.Count); err != nil {
+				if err != nil {
 					return err
 				}
-
-				var resp onDemandResponse
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case resp = <-ch:
-					responsesSeen++
-				case <-time.After(opts.WaitPerRequest):
-					return fmt.Errorf("timed out waiting for on-demand history sync response")
-				}
-
-				mu.Lock()
-				if waitCh == ch {
-					waitCh = nil
-				}
-				mu.Unlock()
 
 				a.emitOrPrint("backfill_response", map[string]any{
 					"chat_jid":       chatStr,
@@ -195,6 +216,7 @@ func (a *App) BackfillHistory(ctx context.Context, opts BackfillOptions) (Backfi
 				}, "On-demand history sync: %d conversations, %d messages.\n", resp.conversations, resp.messages)
 
 				newOldest, err := a.db.GetOldestMessageInfo(chatStr)
+				// A retry's newer anchor is not progress past the original oldest row.
 				if err == nil && newOldest.MsgID == oldest.MsgID {
 					a.emitOrPrint("backfill_stopped", map[string]any{
 						"chat_jid": chatStr,

--- a/internal/app/backfill_test.go
+++ b/internal/app/backfill_test.go
@@ -1,11 +1,16 @@
 package app
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/openclaw/wacli/internal/out"
 	"github.com/openclaw/wacli/internal/store"
 	waProto "go.mau.fi/whatsmeow/binary/proto"
 	"go.mau.fi/whatsmeow/proto/waCommon"
@@ -16,6 +21,189 @@ import (
 	"go.mau.fi/whatsmeow/types/events"
 	"google.golang.org/protobuf/proto"
 )
+
+func TestBackfillHistoryRetriesUnansweredAnchor(t *testing.T) {
+	for _, firstID := range []string{"3EB0-stalled", "AC-stalled"} {
+		t.Run(firstID, func(t *testing.T) {
+			a, f, chat, base := newBackfillRetryTest(t, firstID, "fallback")
+			var eventLog bytes.Buffer
+			a.opts.Events = out.NewEventWriter(&eventLog, true)
+			var anchors []string
+			f.onDemandHistory = func(info types.MessageInfo, count int) *events.HistorySync {
+				anchors = append(anchors, info.ID)
+				if info.ID == firstID {
+					return nil
+				}
+				if info.Chat.String() != chat || !info.IsFromMe || !info.Timestamp.Equal(base) || count != 50 {
+					t.Errorf("fallback request = %+v, count = %d", info, count)
+				}
+				return backfillTestResponse(chat, "older", base.Add(-time.Second))
+			}
+			res, err := a.BackfillHistory(context.Background(), backfillRetryOptions(chat))
+			if err != nil {
+				t.Fatalf("BackfillHistory: %v (anchors %v)", err, anchors)
+			}
+			if !slices.Equal(anchors, []string{firstID, "fallback"}) {
+				t.Fatalf("anchors = %v", anchors)
+			}
+			if res.RequestsSent != 2 || res.ResponsesSeen != 1 || res.MessagesAdded != 1 {
+				t.Fatalf("result = %+v", res)
+			}
+			oldest, err := a.db.GetOldestMessageInfo(chat)
+			if err != nil || oldest.MsgID != "older" {
+				t.Fatalf("oldest = %+v, err = %v", oldest, err)
+			}
+			warnings := 0
+			for _, line := range bytes.Split(bytes.TrimSpace(eventLog.Bytes()), []byte("\n")) {
+				var event struct {
+					Data map[string]any `json:"data"`
+				}
+				if err := json.Unmarshal(line, &event); err != nil {
+					t.Fatalf("invalid lifecycle JSON: %s: %v", line, err)
+				}
+				if event.Data["code"] == "backfill_anchor_retry" {
+					warnings++
+					if event.Data["anchor_msg_id"] != firstID || event.Data["retry_anchor_msg_id"] != "fallback" {
+						t.Fatalf("retry warning = %v", event)
+					}
+				}
+			}
+			if warnings != 1 {
+				t.Fatalf("retry warnings = %d, want 1; events: %s", warnings, &eventLog)
+			}
+		})
+	}
+}
+
+func TestBackfillHistoryRetryStops(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		ids        []string
+		cancel     bool
+		noProgress bool
+		wantCalls  int
+	}{
+		{name: "single anchor", ids: []string{"first"}, wantCalls: 1},
+		{name: "two silent anchors", ids: []string{"first", "second", "third"}, wantCalls: 2},
+		{name: "cancelled", ids: []string{"first", "second"}, cancel: true, wantCalls: 1},
+		{name: "fallback without older history", ids: []string{"first", "second", "third"}, noProgress: true, wantCalls: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, f, chat, base := newBackfillRetryTest(t, tc.ids...)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			calls := 0
+			f.onDemandHistory = func(info types.MessageInfo, count int) *events.HistorySync {
+				calls++
+				if tc.cancel {
+					cancel()
+				}
+				if tc.noProgress && calls == 2 {
+					return backfillTestResponse(chat, "first", base)
+				}
+				return nil
+			}
+			opts := backfillRetryOptions(chat)
+			opts.Requests = 3
+			_, err := a.BackfillHistory(ctx, opts)
+			switch {
+			case tc.cancel:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("error = %v, want cancellation", err)
+				}
+			case tc.noProgress:
+				if err != nil {
+					t.Fatalf("BackfillHistory: %v", err)
+				}
+			default:
+				if err == nil || !strings.Contains(err.Error(), "timed out waiting for on-demand history sync response") {
+					t.Fatalf("error = %v, want timeout", err)
+				}
+			}
+			if calls != tc.wantCalls {
+				t.Fatalf("requests = %d, want %d", calls, tc.wantCalls)
+			}
+		})
+	}
+}
+
+func TestBackfillHistoryContinuesFromRecoveredOldest(t *testing.T) {
+	a, f, chat, base := newBackfillRetryTest(t, "stalled", "fallback")
+	var anchors []string
+	f.onDemandHistory = func(info types.MessageInfo, count int) *events.HistorySync {
+		anchors = append(anchors, info.ID)
+		switch info.ID {
+		case "fallback":
+			return backfillTestResponse(chat, "older", base.Add(-time.Second))
+		case "older":
+			return backfillTestResponse(chat, "oldest", base.Add(-2*time.Second))
+		default:
+			return nil
+		}
+	}
+	opts := backfillRetryOptions(chat)
+	opts.Requests = 2
+	res, err := a.BackfillHistory(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(anchors, []string{"stalled", "fallback", "older"}) || res.RequestsSent != 3 || res.ResponsesSeen != 2 || res.MessagesAdded != 2 {
+		t.Fatalf("anchors = %v, result = %+v", anchors, res)
+	}
+}
+
+func TestBackfillHistoryDoesNotRetryTransportError(t *testing.T) {
+	a, f, chat, _ := newBackfillRetryTest(t, "first", "second")
+	f.onDemandErr = errors.New("transport unavailable")
+	var eventLog bytes.Buffer
+	a.opts.Events = out.NewEventWriter(&eventLog, true)
+	_, err := a.BackfillHistory(context.Background(), backfillRetryOptions(chat))
+	if !errors.Is(err, f.onDemandErr) {
+		t.Fatalf("error = %v, want transport error", err)
+	}
+	if strings.Count(eventLog.String(), `"event":"backfill_requesting"`) != 1 || strings.Contains(eventLog.String(), "backfill_anchor_retry") {
+		t.Fatalf("unexpected retry: %s", &eventLog)
+	}
+}
+
+func newBackfillRetryTest(t *testing.T, ids ...string) (*App, *fakeWA, string, time.Time) {
+	t.Helper()
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+	chat := "123@g.us"
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := a.db.UpsertChat(chat, "group", "Test group", base); err != nil {
+		t.Fatalf("UpsertChat: %v", err)
+	}
+	for i, id := range ids {
+		// Equal timestamps exercise the stable row-ID ordering of adjacent anchors.
+		msg := storeUpsertMessage(chat, id, base, "existing text")
+		msg.FromMe = i == 1
+		if err := a.db.UpsertMessage(msg); err != nil {
+			t.Fatalf("UpsertMessage: %v", err)
+		}
+	}
+	return a, f, chat, base
+}
+
+func backfillRetryOptions(chat string) BackfillOptions {
+	return BackfillOptions{ChatJID: chat, Count: 50, Requests: 1, WaitPerRequest: 10 * time.Millisecond, IdleExit: time.Millisecond}
+}
+
+func backfillTestResponse(chat, id string, timestamp time.Time) *events.HistorySync {
+	return &events.HistorySync{Data: &waHistorySync.HistorySync{
+		SyncType: waHistorySync.HistorySync_ON_DEMAND.Enum(),
+		Conversations: []*waHistorySync.Conversation{{
+			ID: proto.String(chat),
+			Messages: []*waHistorySync.HistorySyncMsg{{Message: &waWeb.WebMessageInfo{
+				Key:              &waCommon.MessageKey{RemoteJID: proto.String(chat), FromMe: proto.Bool(false), ID: proto.String(id)},
+				MessageTimestamp: proto.Uint64(uint64(timestamp.Unix())),
+				Message:          &waProto.Message{Conversation: proto.String("older text")},
+			}}},
+		}},
+	}}
+}
 
 func TestBackfillHistoryAddsOlderMessages(t *testing.T) {
 	a := newTestApp(t)

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -61,6 +61,7 @@ type fakeWA struct {
 	decryptSecretFunc           func(evt *events.Message) (*waE2E.Message, error)
 	onDemandHistory             func(lastKnown types.MessageInfo, count int) *events.HistorySync
 	onDemandEvent               func(lastKnown types.MessageInfo, count int) interface{}
+	onDemandErr                 error
 	downloadHistory             func(notif *waE2E.HistorySyncNotification) (*waHistorySync.HistorySync, error)
 	deleteHistoryCalls          []*waE2E.HistorySyncNotification
 	appStateRecoveryErr         error
@@ -697,13 +698,22 @@ func (f *fakeWA) SendMediaRetryReceipt(ctx context.Context, info *types.MessageI
 
 func (f *fakeWA) RequestHistorySyncOnDemand(ctx context.Context, lastKnown types.MessageInfo, count int) (types.MessageID, error) {
 	f.mu.Lock()
+	if f.onDemandErr != nil {
+		err := f.onDemandErr
+		f.mu.Unlock()
+		return "", err
+	}
 	eventCB := f.onDemandEvent
 	cb := f.onDemandHistory
 	f.mu.Unlock()
 	if eventCB != nil {
-		f.emit(eventCB(lastKnown, count))
+		if evt := eventCB(lastKnown, count); evt != nil {
+			f.emit(evt)
+		}
 	} else if cb != nil {
-		f.emit(cb(lastKnown, count))
+		if evt := cb(lastKnown, count); evt != nil {
+			f.emit(evt)
+		}
 	}
 	return types.MessageID("req"), nil
 }

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -479,6 +479,25 @@ func (d *DB) GetLatestMessageInfo(chatJID string) (MessageInfo, error) {
 	return messageInfoFromLatestRow(row), nil
 }
 
+func (d *DB) GetNextMessageInfo(chatJID, msgID string) (MessageInfo, error) {
+	chatJID = strings.TrimSpace(chatJID)
+	if chatJID == "" {
+		return MessageInfo{}, fmt.Errorf("chat JID is required")
+	}
+	row, err := d.q.GetNextMessageInfo(storeCtx(), storedb.GetNextMessageInfoParams{ChatJid: chatJID, MsgID: msgID})
+	if err != nil {
+		return MessageInfo{}, err
+	}
+	return MessageInfo{
+		ChatJID:    row.ChatJid,
+		MsgID:      row.MsgID,
+		Timestamp:  fromUnix(row.Ts),
+		FromMe:     row.FromMe != 0,
+		SenderJID:  row.SenderJid,
+		SenderName: row.SenderName,
+	}, nil
+}
+
 func (d *DB) MessageContext(chatJID, msgID string, before, after int) ([]Message, error) {
 	if before < 0 {
 		before = 0

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -783,6 +783,51 @@ func TestCountMessagesAndOldestMessageInfo(t *testing.T) {
 	}
 }
 
+func TestGetNextMessageInfo(t *testing.T) {
+	db := openTestDB(t)
+	base := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+	for _, chat := range []string{"123@g.us", "456@g.us"} {
+		if err := db.UpsertChat(chat, "group", "Test group", base); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Insert out of timestamp order, with a tie and an interleaved different chat.
+	for _, msg := range []UpsertMessageParams{
+		{ChatJID: "123@g.us", MsgID: "latest", Timestamp: base.Add(time.Second)},
+		{ChatJID: "123@g.us", MsgID: "first", Timestamp: base},
+		{ChatJID: "456@g.us", MsgID: "other", Timestamp: base},
+		{ChatJID: "123@g.us", MsgID: "second", Timestamp: base, FromMe: true, SenderJID: "789@s.whatsapp.net", SenderName: "Alice"},
+	} {
+		if err := db.UpsertMessage(msg); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, tc := range []struct{ chat, anchor, want string }{
+		{"123@g.us", "first", "second"},
+		{"123@g.us", "second", "latest"},
+		{"123@g.us", "latest", ""},
+		{"123@g.us", "missing", ""},
+		{"456@g.us", "other", ""},
+		{"456@g.us", "first", ""},
+	} {
+		t.Run(tc.chat+"/"+tc.anchor, func(t *testing.T) {
+			next, err := db.GetNextMessageInfo(tc.chat, tc.anchor)
+			if tc.want == "" {
+				if !errors.Is(err, sql.ErrNoRows) {
+					t.Fatalf("error = %v, want no rows", err)
+				}
+				return
+			}
+			if err != nil || next.ChatJID != tc.chat || next.MsgID != tc.want {
+				t.Fatalf("next = %+v, err = %v, want %s", next, err, tc.want)
+			}
+			if tc.want == "second" && (!next.Timestamp.Equal(base) || !next.FromMe || next.SenderJID != "789@s.whatsapp.net" || next.SenderName != "Alice") {
+				t.Fatalf("next lost anchor metadata: %+v", next)
+			}
+		})
+	}
+}
+
 func TestMessageRevokedTombstoneIsHiddenFromListAndSearch(t *testing.T) {
 	db := openTestDB(t)
 

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -298,6 +298,15 @@ WHERE m.chat_jid = ?
 ORDER BY m.ts DESC, m.rowid DESC
 LIMIT 1;
 
+-- name: GetNextMessageInfo :one
+SELECT m.chat_jid, m.msg_id, m.ts, m.from_me, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,'')
+FROM messages m
+JOIN messages anchor ON anchor.chat_jid = m.chat_jid
+WHERE anchor.chat_jid = ? AND anchor.msg_id = ?
+  AND (m.ts, m.rowid) > (anchor.ts, anchor.rowid)
+ORDER BY m.ts ASC, m.rowid ASC
+LIMIT 1;
+
 -- name: MessageContextBefore :many
 SELECT m.rowid, m.chat_jid, COALESCE(c.name,''), m.msg_id, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,''), m.ts, m.from_me, COALESCE(m.text,''), COALESCE(m.display_text,''), COALESCE(m.quoted_msg_id,''), COALESCE(m.quoted_sender_jid,''), m.is_forwarded, m.forwarding_score, COALESCE(m.reaction_to_id,''), COALESCE(m.reaction_emoji,''), COALESCE(m.media_type,''), COALESCE(m.media_caption,''), COALESCE(m.filename,''), COALESCE(m.mime_type,''), COALESCE(m.direct_path,''), COALESCE(m.local_path,''), COALESCE(m.downloaded_at,0), CASE WHEN s.msg_id IS NULL THEN 0 ELSE 1 END, COALESCE(s.starred_at,0), m.revoked, m.deleted_for_me, COALESCE(m.deleted_at,0), COALESCE(m.deletion_reason,''), COALESCE(m.payload_purged_at,0), m.edited, COALESCE(m.buttons,''), ''
 FROM messages m

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -599,6 +599,44 @@ func (q *Queries) GetMessageLocation(ctx context.Context, arg GetMessageLocation
 	return i, err
 }
 
+const getNextMessageInfo = `-- name: GetNextMessageInfo :one
+SELECT m.chat_jid, m.msg_id, m.ts, m.from_me, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,'')
+FROM messages m
+JOIN messages anchor ON anchor.chat_jid = m.chat_jid
+WHERE anchor.chat_jid = ? AND anchor.msg_id = ?
+  AND (m.ts, m.rowid) > (anchor.ts, anchor.rowid)
+ORDER BY m.ts ASC, m.rowid ASC
+LIMIT 1
+`
+
+type GetNextMessageInfoParams struct {
+	ChatJid string
+	MsgID   string
+}
+
+type GetNextMessageInfoRow struct {
+	ChatJid    string
+	MsgID      string
+	Ts         int64
+	FromMe     int64
+	SenderJid  string
+	SenderName string
+}
+
+func (q *Queries) GetNextMessageInfo(ctx context.Context, arg GetNextMessageInfoParams) (GetNextMessageInfoRow, error) {
+	row := q.db.QueryRowContext(ctx, getNextMessageInfo, arg.ChatJid, arg.MsgID)
+	var i GetNextMessageInfoRow
+	err := row.Scan(
+		&i.ChatJid,
+		&i.MsgID,
+		&i.Ts,
+		&i.FromMe,
+		&i.SenderJid,
+		&i.SenderName,
+	)
+	return i, err
+}
+
 const getOldestMessageInfo = `-- name: GetOldestMessageInfo :one
 SELECT m.chat_jid, m.msg_id, m.ts, m.from_me, COALESCE(m.sender_jid,''), COALESCE(m.sender_name,'')
 FROM messages m


### PR DESCRIPTION
## Problem and root cause

History backfill always reuses the oldest local row as its on-demand anchor. When the phone leaves that anchor unanswered, the command exits without advancing it, so later runs repeat the same dead end. The reporter's follow-up establishes that ordinary text-bearing `AC…` IDs can also stall; filtering linked-device prefixes or deleting rows would not fix the underlying control flow.

## Change

After a response timeout, retry once with the next local message ordered by timestamp and row ID. Keep the original oldest row as the progress boundary, so a response containing only existing history stops normally. Transport failures and cancellation do not retry, and a second timeout still returns an error.

The store query uses the existing indexes and preserves the replacement anchor's timestamp and `FromMe` value. Human warnings and NDJSON lifecycle output identify both anchors, and request totals include the actual retry attempts. Help and history documentation explain that each requested batch may make one extra attempt and wait up to twice `--wait`. No message IDs are filtered and no local history is deleted.

Fixes #371. Thanks @Entretoize for the controlled reproduction and correction.

## Proof

The new regression failed on the original implementation for both linked-device-style and ordinary `AC…` anchors: each stopped after one unanswered request. With this change, each recovery case records **2 requests, 1 response, and 1 newly stored older message**. A two-batch continuation records **3 requests, 2 responses, and 2 older messages**, starting the second batch at the recovered oldest row.

Coverage also checks timestamp ties, chat isolation, missing/last anchors, a single local anchor, a silent second anchor despite a third being available, cancellation, transport errors, no-progress responses, and valid NDJSON warnings. A direct SQLite probe over **10,000 rows sharing a timestamp** selected the correct next row and used indexed lookups.

Validation:

- `go test ./internal/app ./internal/store -run 'Test(BackfillHistory|GetNextMessageInfo)' -count=1`
- `go test -race ./internal/app ./internal/store -run 'Test(BackfillHistory|GetNextMessageInfo)' -count=1`
- `pnpm -s docs:site`
- `make check` (format, vet, exact Go version, vulnerability and dead-code checks, plain/FTS tests, Windows lock cross-build, CGO guard, docs tests, build, release configuration checks, and diff whitespace)
- Codex autoreview passed its configured P0 gate with no actionable findings.

The real built `dist/wacli` was exercised against a disposable synthetic store: **1 ready chat, 2 local anchors, 1 fill dry-run candidate**, updated backfill help, and read-only rejection without changing either stored row.

The vulnerability gate continues to report the existing module-level `GO-2026-5932` openpgp notice; it is not suppressed, and the gate found no reachable standard-library vulnerabilities.

No live WhatsApp phone was used and no messages were sent. Anchor silence and recovery are validated through the repository's fake transport and real SQLite persistence; the built-binary checks cover the offline CLI boundary, not provider acceptance of a particular anchor. Multiple consecutive unusable anchors can still exhaust the single retry.
