### PR TITLE
fix(groups): warn when local list results are truncated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Groups: warn on stderr when `groups list` truncates matching results, including JSON output, and keep `--events` warnings machine-readable. (#360 - thanks @hchittanuru3)
 - History: retry an unanswered backfill anchor once with the next local message, report both anchors, and keep retries bounded without deleting history or filtering message IDs. (#371 - thanks @Entretoize)
 
 ### Chore

--- a/cmd/wacli/groups_list_test.go
+++ b/cmd/wacli/groups_list_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openclaw/wacli/internal/store"
+)
+
+func TestGroupsListWarnsOnlyWhenMatchingResultsAreTruncated(t *testing.T) {
+	storeDir := t.TempDir()
+	db, err := store.Open(filepath.Join(storeDir, "wacli.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range 51 {
+		if err := db.UpsertGroup(fmt.Sprintf("%d@g.us", i), "Matching group", "", time.Unix(int64(i+1), 0)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.UpsertGroup("left@g.us", "Matching group", "", time.Unix(100, 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.MarkGroupLeft("left@g.us", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		args   []string
+		rows   int
+		warn   bool
+		events bool
+	}{
+		{name: "default", rows: 50, warn: true},
+		{name: "zero uses default", args: []string{"--limit", "0"}, rows: 50, warn: true},
+		{name: "negative uses default", args: []string{"--limit", "-1"}, rows: 50, warn: true},
+		{name: "matching overflow", args: []string{"--query", "Matching", "--limit", "1"}, rows: 1, warn: true},
+		{name: "exact limit ignores left groups", args: []string{"--limit", "51"}, rows: 51},
+		{name: "below limit", args: []string{"--limit", "52"}, rows: 51},
+		{name: "no matches", args: []string{"--query", "absent"}, rows: 0},
+		{name: "maximum limit", args: []string{"--limit", strconv.Itoa(math.MaxInt)}, rows: 51},
+		{name: "events", args: []string{"--limit", "1"}, rows: 1, warn: true, events: true},
+	} {
+		for _, asJSON := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/json=%t", tc.name, asJSON), func(t *testing.T) {
+				cmd := newGroupsListCmd(&rootFlags{storeDir: storeDir, readOnly: true, asJSON: asJSON, events: tc.events})
+				cmd.SetArgs(tc.args)
+				var stdout string
+				stderr := captureRootStderr(t, func() {
+					stdout = captureRootStdout(t, func() {
+						if err := cmd.Execute(); err != nil {
+							t.Fatal(err)
+						}
+					})
+				})
+				if asJSON {
+					var result struct {
+						Success bool
+						Data    []store.Group
+					}
+					if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+						t.Fatal(err)
+					}
+					if !result.Success || len(result.Data) != tc.rows {
+						t.Fatalf("JSON result = %+v, want %d rows", result, tc.rows)
+					}
+				} else if lines := strings.Count(stdout, "\n"); lines != tc.rows+1 {
+					t.Fatalf("table lines = %d, want %d", lines, tc.rows+1)
+				}
+				if !tc.warn {
+					if stderr != "" {
+						t.Fatalf("unexpected warning: %q", stderr)
+					}
+					return
+				}
+				want := fmt.Sprintf("showing first %d matching groups; more are available; increase --limit", tc.rows)
+				if !strings.Contains(stderr, want) {
+					t.Fatalf("missing truncation warning %q in %q", want, stderr)
+				}
+				if tc.events {
+					var event struct{ Event string }
+					if err := json.Unmarshal([]byte(stderr), &event); err != nil {
+						t.Fatalf("stderr is not one JSON event: %v", err)
+					}
+					if event.Event != "warning" {
+						t.Fatalf("event = %q, want warning", event.Event)
+					}
+				}
+			})
+		}
+	}
+}

--- a/cmd/wacli/groups_refresh_list.go
+++ b/cmd/wacli/groups_refresh_list.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"time"
 
@@ -78,9 +79,27 @@ func newGroupsListCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			gs, err := a.DB().ListGroups(query, limit)
+			if limit <= 0 {
+				limit = 50
+			}
+			fetchLimit := limit
+			if fetchLimit < math.MaxInt {
+				fetchLimit++
+			}
+			gs, err := a.DB().ListGroups(query, fetchLimit)
 			if err != nil {
 				return err
+			}
+			if len(gs) > limit {
+				gs = gs[:limit]
+				message := fmt.Sprintf("showing first %d matching groups; more are available; increase --limit", limit)
+				if flags.events {
+					_ = out.NewEventWriter(os.Stderr, true).Emit("warning", map[string]any{
+						"code": "groups_list_truncated", "message": message, "limit": limit,
+					})
+				} else {
+					_ = out.WriteError(os.Stderr, false, fmt.Errorf("warning: %s", message))
+				}
 			}
 			if flags.asJSON {
 				return out.WriteJSON(os.Stdout, gs)
@@ -111,6 +130,6 @@ func newGroupsListCmd(flags *rootFlags) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&query, "query", "", "search query")
-	cmd.Flags().IntVar(&limit, "limit", 50, "limit")
+	cmd.Flags().IntVar(&limit, "limit", 50, "maximum groups to return (non-positive values use 50)")
 	return cmd
 }

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -35,6 +35,7 @@ wacli groups prune [--days N] [--left-only=false|--include-active] [--dry-run] [
 - Group JIDs use the `...@g.us` server.
 - `list` reads local rows and hides groups marked left. Human output includes the group type (`group`, `community`, or `subgroup`) and parent community JID when known.
 - `list --json` includes `IsParent` for communities and `LinkedParentJID` for subgroups.
+- `list` returns at most 50 matching groups by default; non-positive `--limit` values also use 50. When more matching groups exist, stderr warns that the result is truncated (a warning event with `--events`); increase `--limit` to see more. JSON and table output keep their existing shape.
 - `refresh` fetches joined groups live and updates local rows, including WhatsApp Community hierarchy metadata exposed by whatsmeow.
 - `info` fetches one group live and persists it, including whether the chat is a Community parent or linked subgroup.
 - `create` returns the new live group info and persists it locally. Use `--community` to create a community parent, or `--linked-parent` to create a subgroup inside an existing community.


### PR DESCRIPTION
`groups list` silently returned a capped result even when more matching groups existed. It now fetches one additional matching row and warns on stderr only when output is truncated. The existing JSON array, table columns, and non-positive limit behavior are preserved; `--events` emits a warning event.

Fixes #360.

Validation: regression coverage for filtered overflow, exact limits, left groups, empty results, non-positive and maximum limits, table/JSON output, and NDJSON warnings; full repository gate and docs-site build on an isolated Linux runner with Go 1.27.0; Codex autoreview clean at its default P0 threshold.

Real CLI proof on a synthetic SQLite store containing 51 active matching groups and one left group:

```text
Before: default limit -> 50 rows, stderr empty
After: default limit -> 50 rows, stderr warns that more matching groups exist
After: --limit 0 -> 50 rows and warning (existing limit contract)
After: --limit 1000 -> 51 rows, stderr empty
After: --query 'Synthetic match' --limit 1 -> 1 row and warning
After: --query absent -> 0 rows, stderr empty
After: --events -> valid NDJSON warning on stderr
```

Proof command: `python3 groups-proof.py ./dist/wacli`. The harness initializes a disposable store with the built binary, seeds only synthetic groups via SQLite, and invokes the built CLI in read-only mode with the flags above. No WhatsApp account is required.

<details>
<summary>Reproduce with a synthetic store</summary>

```sh
python3 - ./dist/wacli <<'PY'
import json, pathlib, sqlite3, subprocess, sys, tempfile
binary = str(pathlib.Path(sys.argv[1]).resolve())
with tempfile.TemporaryDirectory(prefix='wacli-groups-proof-') as tmp:
    init=subprocess.run([binary,'--store',tmp,'--json','groups','list'],text=True,capture_output=True)
    assert init.returncode == 0, init.stderr
    with sqlite3.connect(pathlib.Path(tmp)/'wacli.db') as db:
        db.executemany('INSERT INTO groups (jid,name,created_ts,updated_at) VALUES (?,?,?,?)',[(f'{i}@g.us','Synthetic match',i,1) for i in range(1,52)])
        db.execute("INSERT INTO groups (jid,name,created_ts,updated_at,left_at) VALUES ('left@g.us','Synthetic match',999,1,1)")
    for label,extra in [('default',[]),('zero',['--limit','0']),('all',['--limit','1000']),('filtered',['--query','Synthetic match','--limit','1']),('empty',['--query','absent']),('events',['--events'])]:
        args=[binary,'--store',tmp,'--read-only','--json','groups','list',*extra]
        r=subprocess.run(args,text=True,capture_output=True)
        print(label, 'exit='+str(r.returncode),'rows='+str(len(json.loads(r.stdout)['data'] or [])),'stderr='+repr(r.stderr.strip()))
    args=[binary,'--store',tmp,'--read-only','groups','list','--query','Synthetic match','--limit','1']
    r=subprocess.run(args,text=True,capture_output=True)
    print('table', 'exit='+str(r.returncode),'lines='+str(len(r.stdout.splitlines())),'stderr='+repr(r.stderr.strip()))
PY
```

</details>

Local focused tests passed with and without FTS5. The full macOS run hit the app-package 10-minute timeout during SQLite cleanup under heavy host load; the complete Linux gate passed, including that app package in about 14 seconds.
