### PR TITLE
fix(wa): stop reconnect backoff timers on cancel

### DIFF
--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -1003,6 +1003,12 @@ func (c *Client) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay ti
 	opts.AllowQR = false
 	opts.DetachSocket = true
 	delay := minDelay
+	// Start stopped so backoff wait begins only after Connect fails.
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	defer timer.Stop()
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -1010,14 +1016,34 @@ func (c *Client) ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay ti
 		if err := c.Connect(ctx, opts); err == nil {
 			return nil
 		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(delay):
+		if err := waitReconnectBackoff(ctx, timer, delay); err != nil {
+			return err
 		}
 		delay *= 2
 		if delay > maxDelay {
 			delay = maxDelay
 		}
+	}
+}
+
+func waitReconnectBackoff(ctx context.Context, timer *time.Timer, delay time.Duration) error {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(delay)
+	select {
+	case <-ctx.Done():
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
 }

--- a/internal/wa/client_test.go
+++ b/internal/wa/client_test.go
@@ -300,6 +300,52 @@ func TestQRChannelEventError(t *testing.T) {
 	}
 }
 
+func TestWaitReconnectBackoffStopsTimerOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	timer := time.NewTimer(time.Hour)
+	defer timer.Stop()
+
+	err := waitReconnectBackoff(ctx, timer, time.Hour)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitReconnectBackoff err = %v, want context.Canceled", err)
+	}
+	if timer.Stop() {
+		t.Fatal("backoff timer still active after context cancel")
+	}
+}
+
+func TestReconnectWithBackoffHonorsContextCancelDuringBackoff(t *testing.T) {
+	c, err := New(Options{StorePath: filepath.Join(t.TempDir(), "session.db")})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer c.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- c.ReconnectWithBackoff(ctx, time.Hour, time.Hour, ConnectOptions{})
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("reconnect returned before cancel: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("reconnect err = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnect did not return after context cancel")
+	}
+}
+
 func TestBestContactName(t *testing.T) {
 	if BestContactName(types.ContactInfo{Found: false, FullName: "x"}) != "" {
 		t.Fatalf("expected empty for not found")


### PR DESCRIPTION
## What Problem This Solves

`wacli sync --follow` reconnects with exponential backoff after a disconnect. Each failed attempt used `time.After(delay)` in the retry loop. When the caller cancels (SIGINT, `--max-reconnect`, or logout while sleeping), the select returns, but that timer cannot be stopped. It stays in the Go runtime heap until the delay fires.

Under reconnect flapping this leaves one leftover timer per canceled wait. Official `time.After` docs say the underlying timer is not recovered until it fires and recommend `NewTimer` plus `Stop` when the wait can be abandoned.

## Evidence

Terminal output from a live `go run` of the After vs NewTimer cancel path (`/tmp/reconnect-timer-proof.go`), then the patched reconnect wait on this branch.

Before (After-style wait, cancel an hour-long delay):

```console
$ go run /tmp/reconnect-timer-proof.go
after-style: cancel returned; hour timer cannot be stopped
newtimer-style: cancel returned; leftover active=false
```

After this patch, canceling an unauthenticated `ReconnectWithBackoff` with a one-hour min delay returns `context.Canceled` and leaves the reusable timer stopped (`Stop()` is false). The same cancel path used to leave the After timer running until the hour elapsed.

```console
$ go test -c -o /tmp/wa-reconnect.test ./internal/wa
$ /tmp/wa-reconnect.test -test.run TestWaitReconnectBackoffStopsTimerOnCancel -test.v
=== RUN   TestWaitReconnectBackoffStopsTimerOnCancel
--- PASS: TestWaitReconnectBackoffStopsTimerOnCancel (0.00s)
PASS
$ /tmp/wa-reconnect.test -test.run TestReconnectWithBackoffHonorsContextCancelDuringBackoff -test.v
=== RUN   TestReconnectWithBackoffHonorsContextCancelDuringBackoff
--- PASS: TestReconnectWithBackoffHonorsContextCancelDuringBackoff (0.06s)
PASS
```

No WhatsApp account is required: Connect fails immediately without a session (`not authenticated`), then the loop waits on the backoff timer.

## Real behavior proof

- **Behavior or issue addressed:** Canceling reconnect backoff must return promptly and must stop the wait timer so it is not left in the runtime heap until the delay fires.
- **Real environment tested:** macOS, Go toolchain on branch `fix/reconnect-timer-leak` at worktree `/tmp/wacli-F003`, disposable unauthenticated session store.
- **Exact steps or command run after this patch:**

  ```bash
  go run /tmp/reconnect-timer-proof.go
  go test -c -o /tmp/wa-reconnect.test ./internal/wa
  /tmp/wa-reconnect.test -test.run TestWaitReconnectBackoffStopsTimerOnCancel -test.v
  /tmp/wa-reconnect.test -test.run TestReconnectWithBackoffHonorsContextCancelDuringBackoff -test.v
  ```

- **Evidence after fix:** terminal output from the patched wait (see Evidence). After-style cancel cannot stop the hour timer. NewTimer cancel reports `leftover active=false`. The reconnect helper returns `context.Canceled` and `timer.Stop()` is false after cancel.
- **Observed result after fix:** Context cancel unblocks the backoff wait and the timer is stopped and drained before return. The next iteration (or process exit) does not keep a pending After timer for the unused delay.
- **What was not tested:** Live WhatsApp `sync --follow` against a real account, and multi-hour flap with a linked device.

## Summary

`ReconnectWithBackoff` now keeps one `time.Timer`, waits with `Reset` after each failed `Connect`, and `Stop`/drains on cancel. Backoff still measures only wait time, not dial time.

Related: #113 (caller `--max-reconnect` deadline), #325 (logout can cancel during backoff), #266 / #278 (disconnect paths that enter this loop). `time.After` contract: https://pkg.go.dev/time#After
