### PR TITLE
fix(build): select Go 1.27.1 without raising the source minimum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
       - name: pnpm lint
         run: pnpm lint
 
-      - name: Verify exact Go security floor
-        run: test "$(go env GOVERSION)" = "go1.27.0"
+      - name: Verify exact Go build toolchain
+        run: test "$(go env GOVERSION)" = "go1.27.1"
 
       - name: govulncheck source
         run: pnpm govulncheck:source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Chore
 
+- Builds: use Go 1.27.1 for development, CI, release verification, and Docker while retaining the Go 1.27.0 source minimum.
+
 - Dependencies: update whatsmeow, x/crypto, gqlparser, pnpm 11, and the Pages deployment action; keep Corepack bootstrap compatible with a verified integrity pin. (#384 - thanks @thedavidweng)
 - Dependencies: update Go modules, pnpm, CI actions, GoReleaser, and Docker images; require Go 1.27.0 and align local, CI, and release toolchain checks.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 
-FROM golang:1.27.0-alpine@sha256:4c9fe60190a2a3350ddc51de80d0224b8a6698d12bdfc999fee45ea9d6c46dbc AS build
+FROM golang:1.27.1-alpine@sha256:cf6fca6641884b8433441b2b0652976f975e1d0fdd26d177eaaf8596087f3125 AS build
 RUN apk add --no-cache build-base ca-certificates git
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ fmt:
 
 lint:
 	GOWORK=off pnpm --silent lint
-	@test "$$(GOWORK=off go env GOVERSION)" = go1.27.0
+	@test "$$(GOWORK=off go env GOVERSION)" = go1.27.1
 	GOWORK=off pnpm --silent govulncheck:source
 	@set -e; \
 	output_file="$$(mktemp)"; \

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ See [accounts](docs/accounts.md) for store selection and [sync](docs/sync.md) fo
 
 ## Development
 
-Development requires Go 1.27.0, Node.js 24 or newer, pnpm, cgo, and a C compiler.
+Development uses the Go 1.27.1 toolchain selected by `go.mod`, Node.js 24 or newer, pnpm, cgo, and a C compiler. The source minimum remains Go 1.27.0.
 
 ```sh
 pnpm install --frozen-lockfile

--- a/docs/install.md
+++ b/docs/install.md
@@ -61,6 +61,8 @@ GCC 15 has stricter brace-init warnings; the `-Wno-error=missing-braces` flag ke
 The Makefile is a thin wrapper over the existing pnpm scripts. `make build`
 writes `./dist/wacli`; `make check` runs the complete local CI gate.
 
+Repository development, CI, and Docker builds select Go 1.27.1 for its compiler, runtime, cgo, and standard-library fixes. The `toolchain` directive in `go.mod` selects that build version without raising the Go 1.27.0 source minimum; normal Go toolchain auto-selection downloads it when needed.
+
 ## Verify the install
 
 ```bash

--- a/docs/release.md
+++ b/docs/release.md
@@ -13,6 +13,7 @@ wacli uses the fleet-standard reusable Go CLI workflow from `openclaw/release-wo
 - `LICENSE` and `README.md` are preserved in every archive, and the published checksum asset remains `checksums.txt`.
 - Every Darwin binary retains the established `org.openclaw.wacli` identifier and OpenClaw Foundation Developer ID identity.
 - The independent rebuild must reproduce every staged Linux and Windows binary byte-for-byte before publication.
+- Build and verification use the exact preferred `toolchain` from the frozen commit's `go.mod` (currently Go 1.27.1); the `go` directive remains the Go 1.27.0 source minimum. Historical commits without a `toolchain` directive use their exact `go` version.
 - The published release must hand off exact verified assets to `openclaw/homebrew-tap`, then open the next patch's `Unreleased` closeout PR.
 
 ## Dispatch

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openclaw/wacli
 
 go 1.27.0
 
+toolchain go1.27.1
+
 require (
 	github.com/mattn/go-sqlite3 v1.14.50
 	github.com/mdp/qrterminal/v3 v3.2.1

--- a/scripts/release-common.mjs
+++ b/scripts/release-common.mjs
@@ -6,8 +6,8 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 export const RELEASE_REPOSITORY = "openclaw/wacli";
-export const RELEASE_GO_VERSION = "go1.27.0";
-export const RELEASE_GO_TOOLCHAIN = "go1.27.0";
+export const RELEASE_GO_VERSION = "go1.27.1";
+export const RELEASE_GO_TOOLCHAIN = "go1.27.1";
 export const RELEASE_GOVULNCHECK_VERSION = "v1.7.0";
 export const RELEASE_IDENTIFIER = "org.openclaw.wacli";
 export const RELEASE_TEAM_ID = "FWJYW4S8P8";
@@ -47,7 +47,23 @@ export function releaseGoVersionForCommit(commit, options = {}) {
   if (matches.length !== 1) {
     throw new Error(`release commit ${commit} must declare one exact Go version in go.mod`);
   }
-  return `go${matches[0][1]}`;
+  const minimum = matches[0][1];
+  const toolchains = [...String(result.stdout).matchAll(/^toolchain (.+)$/gm)];
+  // Older release commits declared only a go directive.
+  if (toolchains.length === 0) return `go${minimum}`;
+  if (toolchains.length !== 1 || !/^go\d+\.\d+\.\d+$/.test(toolchains[0][1])) {
+    throw new Error(`release commit ${commit} must declare one exact Go toolchain`);
+  }
+  const toolchain = toolchains[0][1];
+  const selected = toolchain.slice(2).split(".").map(Number);
+  const required = minimum.split(".").map(Number);
+  for (let index = 0; index < required.length; index += 1) {
+    if (selected[index] > required[index]) break;
+    if (selected[index] < required[index]) {
+      throw new Error(`release toolchain ${toolchain} is older than go${minimum}`);
+    }
+  }
+  return toolchain;
 }
 
 export function archiveNames(version) {

--- a/scripts/release-go-version.test.mjs
+++ b/scripts/release-go-version.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { releaseGoVersionForCommit } from "./release-common.mjs";
+
+const commit = "a".repeat(40);
+const resolve = (module) => releaseGoVersionForCommit(commit, {
+  run(command, args) {
+    assert.equal(command, "git");
+    assert.deepEqual(args, ["show", `${commit}:go.mod`]);
+    return { stdout: module };
+  },
+});
+
+test("release verification uses the frozen commit's preferred toolchain", () => {
+  assert.equal(resolve("module example.com/cli\n\ngo 1.27.0\n\ntoolchain go1.27.1\n"), "go1.27.1");
+});
+
+test("historical release commits without a toolchain retain their exact Go version", () => {
+  assert.equal(resolve("module example.com/cli\n\ngo 1.26.6\n"), "go1.26.6");
+});
+
+test("release verification rejects ambiguous or non-exact toolchains", () => {
+  for (const directive of ["default", "go1.27", "go1.27.1\ntoolchain go1.27.2"]) {
+    assert.throws(() => resolve(`go 1.27.0\ntoolchain ${directive}\n`), /exact Go toolchain/);
+  }
+});
+
+test("release toolchain cannot be older than the module minimum", () => {
+  assert.throws(() => resolve("go 1.27.0\ntoolchain go1.26.8\n"), /older than/);
+});

--- a/scripts/release-local.mjs
+++ b/scripts/release-local.mjs
@@ -27,6 +27,7 @@ import {
   parseChecksums,
   parseCliArgs,
   releaseAssetNames,
+  releaseGoVersionForCommit,
   releaseManifestDigest,
   runCommand,
   sanitizedExecutionEnv,
@@ -59,9 +60,8 @@ function assertReleaseSource(version, commit, run) {
   if (head !== commit) throw new Error(`release commit ${commit} is not checked out (HEAD is ${head})`);
   run("git", ["merge-base", "--is-ancestor", commit, "origin/main"], { cwd: repoRoot });
 
-  const goMod = fs.readFileSync(path.join(repoRoot, "go.mod"), "utf8");
-  if (goMod.match(/^go (\S+)$/m)?.[1] !== RELEASE_GO_VERSION.slice(2)) {
-    throw new Error(`go.mod must require exact ${RELEASE_GO_VERSION}`);
+  if (releaseGoVersionForCommit(commit, { run }) !== RELEASE_GO_VERSION) {
+    throw new Error(`release commit must select exact ${RELEASE_GO_VERSION}`);
   }
   const rootSource = fs.readFileSync(path.join(repoRoot, "cmd/wacli/root.go"), "utf8");
   if (!rootSource.includes(`const sourceVersion = \"${version}\"`)) {

--- a/scripts/toolchain.test.mjs
+++ b/scripts/toolchain.test.mjs
@@ -5,8 +5,10 @@ import { RELEASE_GO_TOOLCHAIN, RELEASE_GO_VERSION } from "./release-common.mjs";
 
 const read = (file) => readFileSync(new URL(`../${file}`, import.meta.url), "utf8");
 
-test("build and release gates use the Go version declared in go.mod", () => {
-  const version = read("go.mod").match(/^go (\S+)$/m)[1];
+test("build and release gates use the preferred Go toolchain without raising the source minimum", () => {
+  const module = read("go.mod");
+  assert.equal(module.match(/^go (\S+)$/m)[1], "1.27.0");
+  const version = module.match(/^toolchain go(\S+)$/m)[1];
   assert.equal(RELEASE_GO_VERSION, `go${version}`);
   assert.equal(RELEASE_GO_TOOLCHAIN, `go${version}`);
   assert.equal(read("Makefile").match(/GOVERSION\)" = (go\S+)/)[1], `go${version}`);


### PR DESCRIPTION
Use Go 1.27.1 for development, CI, Docker, and release verification while retaining `go 1.27.0` as the supported source minimum. The new `toolchain go1.27.1` directive selects the patch release, and the Docker builder uses its verified multi-platform digest. Go 1.27.1 includes compiler, runtime, cgo, and standard-library fixes ([upstream notes](https://go.dev/doc/devel/release#go1.27.1)).

The artifact verifier previously treated the module's minimum Go version as its build version. It now resolves the preferred toolchain from the exact frozen commit, rejects ambiguous or older toolchains, and retains the exact `go` version for historical commits without a toolchain directive. Local release preparation, CI checks, documentation, and alignment tests use the same distinction. The existing shared release workflow already selects and freezes the toolchain from `go.mod`.

Validation at `82e4d8d23364f5756cab724bea964862b5165d78`:

| Check | Result |
| --- | --- |
| Verifier regression | Before: selected 1.27.0 despite a 1.27.1 toolchain; after: selects 1.27.1 and preserves historical 1.26.6 handling |
| Actual committed Git-source lookup | Current commit selects 1.27.1; parent `67092be` selects 1.27.0 |
| Linux default toolchain and binary metadata | Go 1.27.1 |
| Explicit source-minimum build | `GOTOOLCHAIN=go1.27.0` builds and runs the CLI; binary metadata confirms Go 1.27.0 |
| Linux full gate | Docs, format, vet, plain/FTS Go suites, Windows lock cross-compile, cgo-required check, all 18 script tests, and build pass |
| Source and binary vulnerability gates | No reachable standard-library vulnerability; existing module-level `GO-2026-5932` remains reported |
| Module checks | `go mod verify` and `go mod tidy -diff` pass |
| Built CLI integration | macOS and Linux synthetic SQLite store: stats, listing, FTS search, unauthenticated status, and read-only send rejection pass; store E2E also passes |
| Independent review | P0–P2 scoped-clean |

The first remote attempt stopped before tests at unsupported local Actions hydration; the completed retry used the prepared environment. Remote Git seeding was unavailable, so Git source and diff checks ran locally. No live WhatsApp session or signed release artifacts were exercised. No release, tag, or publication is part of this change.
