### PR TITLE
fix(media): name the lock-free path when the store lock is held

### DIFF
--- a/cmd/wacli/media.go
+++ b/cmd/wacli/media.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/openclaw/wacli/internal/app"
+	"github.com/openclaw/wacli/internal/lock"
 	"github.com/openclaw/wacli/internal/out"
 	"github.com/openclaw/wacli/internal/wa"
 	"github.com/spf13/cobra"
@@ -242,6 +243,12 @@ func newMediaDownloadCmd(flags *rootFlags) *cobra.Command {
 
 			a, lk, err := newApp(ctx, flags, !readOnly, false)
 			if err != nil {
+				// A `sync --follow` holds the lock for its whole run, so waiting
+				// cannot clear it. Name the flag that does not need the lock
+				// rather than leaving the caller to stop their sync.
+				if lock.IsLocked(err) {
+					return fmt.Errorf("%w; to download while sync is running, use --read-only with --output PATH (it takes no store lock, and does not record local_path)", err)
+				}
 				return err
 			}
 			defer closeApp(a, lk)

--- a/cmd/wacli/media_test.go
+++ b/cmd/wacli/media_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openclaw/wacli/internal/lock"
 	"github.com/spf13/cobra"
 )
 
@@ -65,5 +66,40 @@ func TestMediaDownloadReadOnlyRequiresOutput(t *testing.T) {
 	err := execute([]string{"--read-only", "media", "download", "--chat", "chat@s.whatsapp.net", "--id", "mid"})
 	if err == nil || !strings.Contains(err.Error(), "--output is required in read-only mode") {
 		t.Fatalf("execute error = %v, want read-only output requirement", err)
+	}
+}
+
+// `sync --follow` holds the store lock for its entire run, so waiting cannot
+// clear it and the caller has to be told about the path that needs no lock.
+func TestMediaDownloadLockedStoreNamesTheReadOnlyPath(t *testing.T) {
+	storeDir := t.TempDir()
+	lk, err := lock.Acquire(storeDir)
+	if err != nil {
+		t.Fatalf("lock store: %v", err)
+	}
+	defer lk.Release()
+
+	err = execute([]string{"--store", storeDir, "media", "download",
+		"--chat", "15551234567@s.whatsapp.net", "--id", "mid"})
+	if err == nil {
+		t.Fatal("media download unexpectedly succeeded against a locked store")
+	}
+	if !strings.Contains(err.Error(), "store is locked") {
+		t.Fatalf("error = %v, want the original lock error preserved", err)
+	}
+	if !strings.Contains(err.Error(), "--read-only") {
+		t.Fatalf("error = %v, want it to name --read-only", err)
+	}
+}
+
+// The hint belongs to the lock case only: an unrelated failure must not be
+// dressed up as one.
+func TestMediaDownloadReadOnlyLockHintIsNotAddedToOtherErrors(t *testing.T) {
+	err := execute([]string{"--store", t.TempDir(), "media", "download", "--chat", "", "--id", ""})
+	if err == nil {
+		t.Fatal("expected missing-argument failure")
+	}
+	if strings.Contains(err.Error(), "--read-only") {
+		t.Fatalf("error = %v, want no lock hint on an argument error", err)
 	}
 }

--- a/docs/media.md
+++ b/docs/media.md
@@ -23,6 +23,7 @@ Downloads media for a single message.
 - `--output` may be a file path or directory.
 - If `--output` is omitted, media is written under the store media directory.
 - `--read-only` is supported only with explicit `--output`; it writes the file without opening the WhatsApp session store or recording `local_path` / `downloaded_at`.
+- Because it never opens the store for writing, `--read-only` also takes **no store lock**, so it is the way to fetch media while `sync --follow` is running. A follow session holds the lock for its entire run, so a plain `media download` cannot proceed until it stops, and `--lock-wait` only turns the immediate failure into a timeout.
 
 ### Examples
 


### PR DESCRIPTION
## The problem

`sync --follow` holds the store lock for its entire run, so `media download` fails for as long
as a follow session is up:

```
$ wacli media download --chat <jid> --id <id> --lock-wait 3s
timed out waiting for store lock after 3s: store is locked (another wacli is running?)
(pid=25276 acquired_at=2026-09-01T15:50:55)
```

`--lock-wait` cannot rescue it — the lock is never released while sync follows, so waiting only
converts the immediate failure into a timeout. The error names neither fact, so the reachable
conclusion is "media cannot be downloaded while syncing".

That is wrong, and the flag that fixes it is already here. `--read-only` with `--output` never
opens the store for writing, takes no lock, and downloads straight from the CDN using the stored
`DirectPath` + `MediaKey`. Same moment, same held lock:

```
$ wacli media download --read-only --chat <jid> --id <id> --output /tmp/probe.jpg --json
{"success":true,"data":{"bytes":84268,"downloaded":true,"read_only":true, …}}
0.588s
```

`docs/media.md` documents `--read-only` in terms of what it does *not* record
(`local_path` / `downloaded_at`) and never mentions the lock, so nothing connects the failure to
the remedy.

## Why it is worth a hint rather than only a doc line

A downstream bridge of ours carried this comment for months, and shipped a workaround around it:

> THE BRIDGE CANNOT DOWNLOAD MEDIA ITSELF. `wacli sync --follow` holds the store lock for its
> entire life, and `wacli media download` needs that lock […] `--lock-wait` does not rescue it
> either

Every sentence there is true except the conclusion. The workaround polls wacli's private
`messages.local_path` column waiting for the sync process to fetch the file — reaching into
internal schema to get something a supported flag already provides. The error message is where
that misunderstanding was formed, so that is where it is cheapest to correct.

## The change

- `media download` wraps a lock failure with the path that needs no lock. The original error is
  preserved (`%w`), so `store is locked …` still reads exactly as before with the hint appended.
- `docs/media.md` states that read-only takes no store lock and is therefore the way to fetch
  media while `sync --follow` is running, including why `--lock-wait` does not help.
- The hint is scoped to `lock.IsLocked(err)` only, so an argument error or a missing store does
  not get dressed up as a lock problem.

No behaviour changes: nothing new is attempted, nothing is retried, and the read-only path
itself is untouched.

## After-fix proof

Both outcomes against a **real running `sync --follow`** (pid 71170, holding the store lock
since 15:37), using a binary built from this branch. Chat JID, message ID and output path
redacted:

```
$ wacli media download --chat <redacted> --id <redacted>
store is locked (another wacli is running?): store locked: resource temporarily unavailable
(pid=71170 acquired_at=2026-09-04T15:37:01-04:00); to download while sync is running, use
--read-only with --output PATH (it takes no store lock, and does not record local_path)

$ wacli media download --read-only --chat <redacted> --id <redacted> --output /tmp/photo.jpg --json
{"success":true,"data":{"bytes":272076,"downloaded":true,"read_only":true,"recorded":false,
 "media_type":"image","mime_type":"image/jpeg","path":"/tmp/photo.jpg"}, "error":null}

file on disk: 272076 bytes
```

The hint appears on the same held lock that the read-only invocation then downloads through, so
the advice is verified rather than asserted. It also survives `--lock-wait` (the timeout message
carries it too) and `--json` mode, checked separately against a temp store with an exclusive
`flock` held by another process:

```
$ wacli media download … --lock-wait 3s
timed out waiting for store lock after 3s: store is locked …; to download while sync is running,
use --read-only with --output PATH (…)

$ wacli --json media download …
{"success":false,"data":null,"error":"store is locked …; to download while sync is running, use
--read-only with --output PATH (…)"}
```

## Tests

`TestMediaDownloadLockedStoreNamesTheReadOnlyPath` acquires the lock, runs `media download`
against it, and asserts both that the original `store is locked` text survives and that the
error names `--read-only`. `TestMediaDownloadReadOnlyLockHintIsNotAddedToOtherErrors` covers the
scoping. The first fails when the hint text is changed to anything that does not name the flag.

## Testing

Full gate on macOS/arm64, Go 1.27.1: `gofmt -l .` clean, `go vet ./...` clean, `go test ./...`
and `go test -tags sqlite_fts5 ./...` pass, `go build -tags sqlite_fts5 ./...` ok, Windows lock
cross-compile ok, CGO-required gate ok, `node --test scripts/*.test.mjs` pass, `git diff --check`
clean.


Restacked independently onto current main after #376 and #390 landed. This PR now contains code, documentation, and tests only; its changelog entry and contributor credit are maintained in #391.
