### PR TITLE
fix(sync): serialize webhook timestamps as UTC

### DIFF
--- a/docs/sync.md
+++ b/docs/sync.md
@@ -50,7 +50,9 @@ Webhook payloads remain flat JSON objects. Receipt and chat-presence payloads ca
 an `EventType` discriminator. Message payloads deliberately omit it so existing
 consumers retain the established object shape; a missing `EventType` means
 `message`. Every JID field uses the same identity namespace as the local store:
-known LIDs are resolved to phone JIDs, while unknown LIDs remain unchanged.
+known LIDs are resolved to phone JIDs, while unknown LIDs remain unchanged. Every
+`Timestamp` is UTC (RFC 3339, `Z`), independent of the host's zone, matching the
+store and the CLI's JSON output.
 
 Messages use the stored live message payload documented above:
 

--- a/internal/app/webhook_events.go
+++ b/internal/app/webhook_events.go
@@ -163,7 +163,7 @@ func newSyncWebhookReceiptEvent(evt *events.Receipt) (syncWebhookEvent, bool) {
 			Chat:       evt.Chat,
 			Sender:     evt.Sender,
 			MessageIDs: ids,
-			Timestamp:  evt.Timestamp,
+			Timestamp:  evt.Timestamp.UTC(), // see ParseLiveMessage: the wire format must not follow the host's zone
 			Type:       receiptType,
 			IsFromMe:   evt.IsFromMe,
 		},

--- a/internal/app/webhook_timestamp_test.go
+++ b/internal/app/webhook_timestamp_test.go
@@ -1,0 +1,70 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openclaw/wacli/internal/wa"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+func fixedOffsetZone() *time.Location { return time.FixedZone("test-0400", -4*60*60) }
+
+// docs/sync.md documents `Z` for every webhook Timestamp, and the store and CLI
+// already emit it. The payload is where a host-local value would otherwise reach
+// a consumer, so pin the serialized bytes rather than the Go value.
+func TestWebhookMessagePayloadSerializesTimestampAsUTC(t *testing.T) {
+	a := newTestApp(t)
+	local := time.Date(2026, 9, 4, 14, 57, 52, 0, fixedOffsetZone())
+	chat, _ := types.ParseJID("15551234567@s.whatsapp.net")
+
+	pm := wa.ParseLiveMessage(&events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat},
+			ID:            "MSGID",
+			Timestamp:     local,
+		},
+		Message: &waProto.Message{Conversation: proto.String("hi")},
+	})
+
+	body, err := json.Marshal(a.newSyncWebhookPayload(context.Background(), pm))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(body), `"Timestamp":"2026-09-04T18:57:52Z"`) {
+		t.Fatalf("message payload timestamp is not UTC: %s", body)
+	}
+}
+
+// Receipts carry the raw event time and are the other payload kind the docs
+// show with a `Z`.
+func TestWebhookReceiptPayloadSerializesTimestampAsUTC(t *testing.T) {
+	a := newTestApp(t)
+	local := time.Date(2026, 9, 4, 14, 57, 53, 0, fixedOffsetZone())
+	chat, _ := types.ParseJID("120363000000000000@g.us")
+	sender, _ := types.ParseJID("15551234567@s.whatsapp.net")
+
+	evt, ok := newSyncWebhookReceiptEvent(&events.Receipt{
+		MessageSource: types.MessageSource{Chat: chat, Sender: sender},
+		MessageIDs:    []types.MessageID{"MSGID"},
+		Type:          types.ReceiptTypeDelivered,
+		Timestamp:     local,
+	})
+	if !ok {
+		t.Fatal("expected a receipt webhook event")
+	}
+
+	body, err := json.Marshal(a.newSyncWebhookEventPayload(context.Background(), evt))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(body), `"Timestamp":"2026-09-04T18:57:53Z"`) {
+		t.Fatalf("receipt payload timestamp is not UTC: %s", body)
+	}
+}

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -104,9 +104,12 @@ type ParsedMessage struct {
 
 func ParseLiveMessage(evt *events.Message) ParsedMessage {
 	msg := ParsedMessage{
-		Chat:      evt.Info.Chat,
-		ID:        evt.Info.ID,
-		Timestamp: evt.Info.Timestamp,
+		Chat: evt.Info.Chat,
+		ID:   evt.Info.ID,
+		// UTC, matching ParseHistoryMessage: this value is marshalled straight
+		// into webhook payloads, where the host's zone would otherwise decide
+		// the wire format. The instant is unchanged.
+		Timestamp: evt.Info.Timestamp.UTC(),
 		FromMe:    evt.Info.IsFromMe,
 		PushName:  evt.Info.PushName,
 	}

--- a/internal/wa/messages_timestamp_test.go
+++ b/internal/wa/messages_timestamp_test.go
@@ -1,0 +1,53 @@
+package wa
+
+import (
+	"testing"
+	"time"
+
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+// The parsed timestamp is marshalled straight into webhook payloads, so its
+// location decides the wire format. whatsmeow hands the event time over in the
+// host's zone, which would make one message serialize differently per machine.
+func TestParseLiveMessageNormalizesTimestampToUTC(t *testing.T) {
+	zone := time.FixedZone("test-0400", -4*60*60)
+	local := time.Date(2026, 9, 4, 14, 57, 52, 0, zone)
+	chat, _ := types.ParseJID("15551234567@s.whatsapp.net")
+
+	pm := ParseLiveMessage(&events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat},
+			ID:            "MSGID",
+			Timestamp:     local,
+		},
+		Message: &waProto.Message{Conversation: proto.String("hi")},
+	})
+
+	if pm.Timestamp.Location() != time.UTC {
+		t.Fatalf("timestamp location = %v, want UTC", pm.Timestamp.Location())
+	}
+	// Same instant, different spelling: normalizing must not shift the clock.
+	if !pm.Timestamp.Equal(local) {
+		t.Fatalf("timestamp = %s, want the same instant as %s", pm.Timestamp, local)
+	}
+	if got := pm.Timestamp.Format(time.RFC3339); got != "2026-09-04T18:57:52Z" {
+		t.Fatalf("serialized timestamp = %s, want 2026-09-04T18:57:52Z", got)
+	}
+}
+
+// ParseHistoryMessage already normalized; pinned so the two paths cannot drift
+// apart again.
+func TestParseHistoryMessageTimestampIsUTC(t *testing.T) {
+	pm := ParseHistoryMessage("15551234567@s.whatsapp.net", &waProto.WebMessageInfo{
+		Key:              &waProto.MessageKey{ID: proto.String("HIST")},
+		MessageTimestamp: proto.Uint64(1788548272),
+		Message:          &waProto.Message{Conversation: proto.String("hi")},
+	})
+	if pm.Timestamp.Location() != time.UTC {
+		t.Fatalf("timestamp location = %v, want UTC", pm.Timestamp.Location())
+	}
+}


### PR DESCRIPTION
Fixes #386.

Live message and receipt webhook timestamps currently inherit the host timezone, while history parsing and stored-message JSON use UTC. This change applies UTC at the live parser and receipt constructor so the same instant always serializes with `Z`. Payload fields and stored Unix timestamps are unchanged.

This intentionally changes timestamp string bytes for non-UTC hosts. Consumers parsing RFC 3339 retain the same instant; consumers matching local-offset strings need to accept UTC. The documentation states the correction; its Unreleased entry and contributor credit are centralized in #391.

The contributor's real linked-device before/after trace covers both paths on the same -04:00 host: previously 23/23 message webhooks carried local offsets; the branch emitted UTC for two messages and two delivered receipts. See the [real-device proof](https://github.com/openclaw/wacli/pull/388#issuecomment-5547592432).

Maintainer verification used the production live parser with a fixed -04:00 timestamp, persisted its result to a synthetic SQLite store, and read it through the actual built CLI's FTS search: both serialized as `2026-09-04T18:57:52Z` with the original instant preserved. No personal store or live WhatsApp account was used for that additional check.

The full local gate passed on macOS with Go 1.27.1: formatting, vet, plain and FTS suites, Windows lock cross-compile, CGO-required check, all 18 documentation/toolchain/release tests, build, and whitespace checks. Independent Codex local and branch autoreview are scoped-clean at P0–P2. The history timestamp test preserves existing behavior; the live and receipt tests cover the regression.

The previously reported build conflict with #379 is resolved in that PR's current head, which no longer changes the payload-builder signature. Contributor authorship is preserved; the changelog entry and credit are centralized in #391.


Restacked independently onto current main after #376 and #390 landed. This PR now contains code, documentation, and tests only; its changelog entry and contributor credit are maintained in #391.
