### PR TITLE
chore(release): prepare 0.17.2 patch notes and source version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,20 @@
 
 ## Unreleased
 
-### Fixed
-
-- Contacts: bound system-contact exports while reading the macOS helper, preserving the existing 10 MiB file-import limit. (#376 - thanks @SebTardif)
+**Highlights:** more complete searchable message history, bounded backfill retries, and clearer guidance for commands used alongside continuous sync.
 
 - Messages: extract comment bodies and album summaries in live/history sync, preserving comment reply targets and matching quote metadata. (#383 - thanks @shishiv and @Entretoize)
-
-- CLI: keep successful JSON commands successful when a pipe reader closes early, including Unix stdout SIGPIPE and Windows closed-pipe errors. (#366 - thanks @SebTardif)
-- Groups: warn on stderr when `groups list` truncates matching results, including JSON output, and keep `--events` warnings machine-readable. (#360 - thanks @hchittanuru3)
-- Sync: update whatsmeow so incoming socket frames use the active connection context.
 - History: retry an unanswered backfill anchor once with the next local message, report both anchors, and keep retries bounded without deleting history or filtering message IDs. (#371 - thanks @Entretoize)
-- Messages: omit synthetic audio captions while preserving supplied text and the `[Audio]` display fallback; ordinary re-ingestion can correct legacy captions without migrating untouched rows. (#378 - thanks @hchittanuru3)
-
-### Chore
-
-- Dependencies: update SQLite, WhatsApp transport, SQL tooling, protobuf APIs, pnpm 12.3.1, and its setup action while retaining the Go and Node source minimums.
-
-- Builds: use Go 1.27.1 for development, CI, release verification, and Docker while retaining the Go 1.27.0 source minimum.
-
-- Dependencies: update whatsmeow, x/crypto, gqlparser, pnpm 11, and the Pages deployment action; keep Corepack bootstrap compatible with a verified integrity pin. (#384 - thanks @thedavidweng)
-- Dependencies: update Go modules, pnpm, CI actions, GoReleaser, and Docker images; require Go 1.27.0 and align local, CI, and release toolchain checks.
+- Sync: serialize message and receipt webhook timestamps as UTC, preserving their instants while replacing host-local offsets with the documented `Z` form. (#386, #388 - thanks @hchittanuru3)
+- Media: explain how `media download --read-only --output PATH` bypasses the store lock held by continuous sync. (#387 - thanks @hchittanuru3)
+- Messages: omit synthetic audio captions while preserving supplied text and the `[Audio]` display fallback; re-ingestion can correct legacy captions without migrating untouched rows. (#378 - thanks @hchittanuru3)
+- CLI: keep successful JSON commands successful when a pipe reader closes early, including Unix SIGPIPE and Windows closed-pipe errors. (#366 - thanks @SebTardif)
+- Groups: warn on stderr when `groups list` truncates matching results, including JSON output, and keep `--events` warnings machine-readable. (#360 - thanks @hchittanuru3)
+- Contacts: bound system-contact exports and their helper processes while preserving the existing 10 MiB file-import limit. (#376 - thanks @SebTardif)
+- Docs: render nested heading links and table-of-contents labels safely, preserving links and stable heading anchors. (#370 - thanks @vincentkoc)
+- WhatsApp compatibility: update socket-context handling, message identity parsing, group deletion handling, and disconnect event processing through whatsmeow updates.
+- Builds: use Go 1.27.1 for development, CI, release verification, and Docker while retaining the Go 1.27.0 source minimum; source builds now identify the upcoming 0.17.2 patch.
+- Dependencies: refresh Go modules, pnpm 12.3.1, CI actions, GoReleaser, and Docker images, retaining a verified package-manager integrity pin. (#384 - thanks @thedavidweng)
 
 ## v0.17.1 - 2026-08-14
 

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const sourceVersion = "0.16.0"
+const sourceVersion = "0.17.2"
 
 var version string
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -19,7 +19,7 @@ wacli uses the fleet-standard reusable Go CLI workflow from `openclaw/release-wo
 ## Dispatch
 
 ```bash
-gh workflow run release.yml --repo openclaw/wacli --ref main -f version=0.15.1
+gh workflow run release.yml --repo openclaw/wacli --ref main -f version=0.17.2
 ```
 
 Watch the exact run through completion. A successful run is not sufficient on its own: verify the public release is non-draft and non-prerelease, its tag peels to the frozen protected-main commit, every expected asset is present, `checksums.txt` validates the downloaded assets, both native macOS verifier jobs passed, the Homebrew update run succeeded, and the closeout PR was opened.


### PR DESCRIPTION
Prepare the next patch as 0.17.2. Source builds still report 0.16.0 despite the published v0.17.1 release; this updates the source fallback and release-command example, and rewrites Unreleased in user-impact order with the missing documentation-rendering entry and contributor credit.

#376 and #390 are now on main. Land this PR after #387 and #388; it owns the single complete Unreleased section for all four changes. Its notes intentionally describe that prepared release set. It includes no roster, chat-state delegation, backlog-event, passkey, or logout-contract feature decision.

Validation: the full local gate passed, both actual CLI version entrypoints report 0.17.2, and every released changelog section is byte-for-byte unchanged. Independent local and branch autoreview are scoped-clean at P0–P2.

This is preparation only. After the approved lands, require green CI on the final main SHA, turn Unreleased into the dated 0.17.2 section, and separately authorize the shared release workflow. Publication must verify signed/notarized Darwin binaries, reproducible Linux/Windows artifacts, checksums, the finalized GitHub Release, Homebrew handoff, and the next Unreleased closeout. The npm manifest is private; there is no npm publication step.
