### PR TITLE
chore(release): prepare v0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.17.2 - 2026-09-05
 
 **Highlights:** more complete searchable message history, bounded backfill retries, and clearer guidance for commands used alongside continuous sync.
 


### PR DESCRIPTION
Dates the existing changelog as 0.17.2 for the authorized patch release. The Highlights line, entry ordering, and all release-note content are unchanged; the source version already reports 0.17.2.

Validation: full local gate and documentation-site build passed, and the built CLI reports `wacli 0.17.2`. Publication will run through the documented unified release workflow after CI is green on the merged release commit.
