### PR TITLE
feat(send): add opt-in self text sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Send: add opt-in `send text --allow-self` for deployments that intentionally attempt linked-account self-messages; keep the fail-closed default because WhatsApp may acknowledge these messages without delivering them to Message Yourself.
+
 ## 0.17.2 - 2026-09-05
 
 **Highlights:** more complete searchable message history, bounded backfill retries, and clearer guidance for commands used alongside continuous sync.

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -46,6 +46,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 	var replyTo string
 	var replyToSender string
 	var noPreview bool
+	var allowSelf bool
 	var ephemeral bool
 	var ephemeralDuration string
 	var messageEscapes bool
@@ -91,6 +92,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 					ReplyTo:              replyTo,
 					ReplyToSender:        replyToSender,
 					NoPreview:            noPreview,
+					AllowSelf:            allowSelf,
 					Ephemeral:            ephemeralOpts.Enabled,
 					EphemeralDuration:    ephemeralOpts.Duration,
 					EphemeralDurationSet: ephemeralOpts.DurationSet,
@@ -114,8 +116,10 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := validateTextRecipient(a.WA(), toJID); err != nil {
-				return err
+			if !allowSelf {
+				if err := validateTextRecipient(a.WA(), toJID); err != nil {
+					return err
+				}
 			}
 			mentionedJIDs, err := parseMentionedJIDs(mentions)
 			if err != nil {
@@ -131,7 +135,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 
 			preview := fetchLinkPreview(ctx, message, noPreview)
 			msgID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
-				return sendTextMessage(ctx, a, toJID, message, replyTo, replyToSender, preview, mentionedJIDs, ephemeralOpts)
+				return sendTextMessageWithOptions(ctx, a, toJID, message, replyTo, replyToSender, preview, mentionedJIDs, ephemeralOpts, textSendOptions{allowSelf: allowSelf})
 			})
 			if err != nil {
 				return err
@@ -163,6 +167,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 	cmd.Flags().StringVar(&replyTo, "reply-to", "", "message ID to quote/reply to")
 	cmd.Flags().StringVar(&replyToSender, "reply-to-sender", "", "sender JID of the quoted message (required for unsynced group replies)")
 	cmd.Flags().BoolVar(&noPreview, "no-preview", false, "disable automatic link previews for the first URL in text")
+	cmd.Flags().BoolVar(&allowSelf, "allow-self", false, "allow sending to the linked account itself (delivery is not guaranteed)")
 	cmd.Flags().BoolVar(&ephemeral, "ephemeral", false, "send with the disappearing-message timer for this chat")
 	cmd.Flags().StringVar(&ephemeralDuration, "ephemeral-duration", "", "disappearing-message timer override (for example 24h, 7d, 90d, 168h)")
 	cmd.Flags().BoolVar(&messageEscapes, "message-escapes", false, `interpret backslash escapes in --message (\n, \r, \t, \\, \")`)
@@ -230,6 +235,10 @@ type textEphemeralOptions struct {
 	DurationSet bool
 }
 
+type textSendOptions struct {
+	allowSelf bool
+}
+
 type resolvedTextEphemeral struct {
 	enabled       bool
 	hasExpiration bool
@@ -241,12 +250,22 @@ const defaultEphemeralExpiration uint32 = 7 * 24 * 60 * 60
 var errSelfTextRecipient = errors.New("send text to the linked account itself is not supported: WhatsApp can acknowledge self-messages without delivering them; use the official Message Yourself chat")
 
 func sendTextMessage(ctx context.Context, a sendTextApp, to types.JID, text, replyTo, replyToSender string, preview *linkpreview.Preview, mentionedJIDs []string, ephemeral textEphemeralOptions) (types.MessageID, error) {
-	return sendTextMessageWithSender(ctx, a.WA(), a.DB(), to, text, replyTo, replyToSender, preview, mentionedJIDs, ephemeral)
+	return sendTextMessageWithOptions(ctx, a, to, text, replyTo, replyToSender, preview, mentionedJIDs, ephemeral, textSendOptions{})
+}
+
+func sendTextMessageWithOptions(ctx context.Context, a sendTextApp, to types.JID, text, replyTo, replyToSender string, preview *linkpreview.Preview, mentionedJIDs []string, ephemeral textEphemeralOptions, options textSendOptions) (types.MessageID, error) {
+	return sendTextMessageWithSenderOptions(ctx, a.WA(), a.DB(), to, text, replyTo, replyToSender, preview, mentionedJIDs, ephemeral, options)
 }
 
 func sendTextMessageWithSender(ctx context.Context, sender textMessageSender, db *store.DB, to types.JID, text, replyTo, replyToSender string, preview *linkpreview.Preview, mentionedJIDs []string, ephemeral textEphemeralOptions) (types.MessageID, error) {
-	if err := validateTextRecipient(sender, to); err != nil {
-		return "", err
+	return sendTextMessageWithSenderOptions(ctx, sender, db, to, text, replyTo, replyToSender, preview, mentionedJIDs, ephemeral, textSendOptions{})
+}
+
+func sendTextMessageWithSenderOptions(ctx context.Context, sender textMessageSender, db *store.DB, to types.JID, text, replyTo, replyToSender string, preview *linkpreview.Preview, mentionedJIDs []string, ephemeral textEphemeralOptions, options textSendOptions) (types.MessageID, error) {
+	if !options.allowSelf {
+		if err := validateTextRecipient(sender, to); err != nil {
+			return "", err
+		}
 	}
 	var aliasTo types.JID
 	if strings.TrimSpace(replyTo) != "" {

--- a/cmd/wacli/send_ipc.go
+++ b/cmd/wacli/send_ipc.go
@@ -36,6 +36,7 @@ type sendDelegateRequest struct {
 	ReplyTo              string   `json:"reply_to,omitempty"`
 	ReplyToSender        string   `json:"reply_to_sender,omitempty"`
 	NoPreview            bool     `json:"no_preview,omitempty"`
+	AllowSelf            bool     `json:"allow_self,omitempty"`
 	Ephemeral            bool     `json:"ephemeral,omitempty"`
 	EphemeralDuration    string   `json:"ephemeral_duration,omitempty"`
 	EphemeralDurationSet bool     `json:"ephemeral_duration_set,omitempty"`
@@ -356,8 +357,10 @@ func executeDelegatedText(ctx context.Context, a *app.App, req sendDelegateReque
 	if err != nil {
 		return sendDelegateResponse{}, err
 	}
-	if err := validateTextRecipient(a.WA(), toJID); err != nil {
-		return sendDelegateResponse{}, err
+	if !req.AllowSelf {
+		if err := validateTextRecipient(a.WA(), toJID); err != nil {
+			return sendDelegateResponse{}, err
+		}
 	}
 	toJID = warmupDelegatedRecipient(ctx, a, toJID)
 	mentionedJIDs, err := parseMentionedJIDs(req.Mentions)
@@ -369,7 +372,7 @@ func executeDelegatedText(ctx context.Context, a *app.App, req sendDelegateReque
 	}
 	preview := fetchLinkPreview(ctx, req.Message, req.NoPreview)
 	msgID, err := runSendOperation(ctx, reconnectForSend(a), func(ctx context.Context) (types.MessageID, error) {
-		return sendTextMessage(ctx, a, toJID, req.Message, req.ReplyTo, req.ReplyToSender, preview, mentionedJIDs, ephemeral)
+		return sendTextMessageWithOptions(ctx, a, toJID, req.Message, req.ReplyTo, req.ReplyToSender, preview, mentionedJIDs, ephemeral, textSendOptions{allowSelf: req.AllowSelf})
 	})
 	if err != nil {
 		return sendDelegateResponse{}, err

--- a/cmd/wacli/send_ipc_test.go
+++ b/cmd/wacli/send_ipc_test.go
@@ -86,6 +86,68 @@ func TestSendDelegateRequestPreservesEphemeralInJSON(t *testing.T) {
 	}
 }
 
+func TestSendDelegateRequestPreservesAllowSelfInJSON(t *testing.T) {
+	raw, err := json.Marshal(sendDelegateRequest{
+		Version:   sendDelegateVersion,
+		Kind:      "text",
+		AllowSelf: true,
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"allow_self":true`) {
+		t.Fatalf("encoded request missing allow-self flag: %s", raw)
+	}
+
+	var got sendDelegateRequest
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !got.AllowSelf {
+		t.Fatalf("AllowSelf = false, want true")
+	}
+}
+
+func TestSendTextAllowSelfDelegatesThroughSendSocketWhenStoreLocked(t *testing.T) {
+	skipPresenceDelegateSocketTestOnUnsupportedOS(t)
+	storeDir := shortPresenceDelegateStoreDir(t)
+	lk, err := lock.Acquire(storeDir)
+	if err != nil {
+		t.Fatalf("lock store: %v", err)
+	}
+	defer lk.Release()
+
+	server := startPresenceDelegateTestSocket(t, storeDir, func(req sendDelegateRequest) sendDelegateResponse {
+		return sendDelegateResponse{OK: true, Sent: true, To: "15551234567@s.whatsapp.net", ID: "self-id"}
+	})
+	defer server.stop()
+
+	stdout, stderr, err := runPresenceDelegateHelper(t, []string{
+		"--store", storeDir, "--json", "--timeout", "750ms",
+		"send", "text", "--to", "+15551234567", "--message", "self-test", "--allow-self",
+	})
+	if err != nil {
+		t.Fatalf("send text failed: %v stdout=%q stderr=%q", err, stdout, stderr)
+	}
+
+	req := server.nextRequest(t)
+	if req.Version != sendDelegateVersion || req.Kind != "text" {
+		t.Fatalf("delegate version/kind = %d/%q", req.Version, req.Kind)
+	}
+	if !req.AllowSelf {
+		t.Fatalf("delegate AllowSelf = false, want true")
+	}
+	if req.To != "+15551234567" || req.Message != "self-test" {
+		t.Fatalf("delegate text request = %+v", req)
+	}
+	if strings.Contains(stderr, "store is locked") {
+		t.Fatalf("delegated command tried the direct store path: stderr=%q", stderr)
+	}
+	if !strings.Contains(stdout, `"sent":true`) || !strings.Contains(stdout, `"id":"self-id"`) {
+		t.Fatalf("stdout %q missing delegated success", stdout)
+	}
+}
+
 func TestSendDelegateRequestPreservesReplyInJSON(t *testing.T) {
 	raw, err := json.Marshal(sendDelegateRequest{
 		Version:       sendDelegateVersion,

--- a/cmd/wacli/send_ipc_test.go
+++ b/cmd/wacli/send_ipc_test.go
@@ -148,6 +148,31 @@ func TestSendTextAllowSelfDelegatesThroughSendSocketWhenStoreLocked(t *testing.T
 	}
 }
 
+func TestSendTextAllowSelfPreservesOlderDelegateRejection(t *testing.T) {
+	skipPresenceDelegateSocketTestOnUnsupportedOS(t)
+	storeDir := shortPresenceDelegateStoreDir(t)
+	lk, err := lock.Acquire(storeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lk.Release()
+	server := startPresenceDelegateTestSocket(t, storeDir, func(req sendDelegateRequest) sendDelegateResponse {
+		// Older daemons ignore allow_self and retain their self-recipient guard.
+		return sendDelegateResponse{OK: false, Error: errSelfTextRecipient.Error()}
+	})
+	defer server.stop()
+	stdout, stderr, err := runPresenceDelegateHelper(t, []string{
+		"--store", storeDir, "--json", "--timeout", "2s",
+		"send", "text", "--to", "+15551234567", "--message", "self-test", "--allow-self",
+	})
+	if err == nil || !strings.Contains(stderr, errSelfTextRecipient.Error()) || strings.Contains(stdout, `"sent":true`) {
+		t.Fatalf("older delegate rejection: err=%v stdout=%q stderr=%q", err, stdout, stderr)
+	}
+	if !server.nextRequest(t).AllowSelf {
+		t.Fatal("opt-in did not reach the delegate")
+	}
+}
+
 func TestSendDelegateRequestPreservesReplyInJSON(t *testing.T) {
 	raw, err := json.Marshal(sendDelegateRequest{
 		Version:       sendDelegateVersion,

--- a/cmd/wacli/send_test.go
+++ b/cmd/wacli/send_test.go
@@ -179,6 +179,19 @@ func TestSendTextToOwnPNRejectsWithoutRegistrationCanonicalization(t *testing.T)
 	}
 }
 
+func TestSendTextToOwnPNAllowsExplicitOptIn(t *testing.T) {
+	pn := types.NewJID("15551234567", types.DefaultUserServer)
+	sender := &recordingTextSender{linkedJID: pn.String()}
+
+	_, err := sendTextMessageWithSenderOptions(context.Background(), sender, openSendTestDB(t), pn, "self-test", "", "", nil, nil, textEphemeralOptions{}, textSendOptions{allowSelf: true})
+	if err != nil {
+		t.Fatalf("sendTextMessageWithSenderOptions: %v", err)
+	}
+	if sender.textCalls != 1 || sender.textRecipient != pn || sender.text != "self-test" {
+		t.Fatalf("self-send protocol call = %d to %s text %q, want one call to %s", sender.textCalls, sender.textRecipient, sender.text, pn)
+	}
+}
+
 func TestPersistOutboundTextCanonicalizesSelfLIDToPN(t *testing.T) {
 	db := openSendTestDB(t)
 	pn := types.NewJID("15551234567", types.DefaultUserServer)
@@ -800,6 +813,17 @@ func TestSendTextCommandExposesNoPreviewFlag(t *testing.T) {
 	cmd := newSendTextCmd(&rootFlags{})
 	if cmd.Flags().Lookup("no-preview") == nil {
 		t.Fatalf("missing --no-preview flag")
+	}
+}
+
+func TestSendTextCommandExposesAllowSelfFlag(t *testing.T) {
+	cmd := newSendTextCmd(&rootFlags{})
+	flag := cmd.Flags().Lookup("allow-self")
+	if flag == nil {
+		t.Fatalf("missing --allow-self flag")
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("allow-self default = %q, want false", flag.DefValue)
 	}
 }
 

--- a/docs/send.md
+++ b/docs/send.md
@@ -9,7 +9,7 @@ When `sync --follow` is already running for the same store, send commands delega
 ## Commands
 
 ```bash
-wacli send text --to RECIPIENT --message TEXT [--message-escapes] [--pick N] [--mention USER] [--no-preview] [--ephemeral] [--ephemeral-duration DURATION] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
+wacli send text --to RECIPIENT --message TEXT [--message-escapes] [--pick N] [--mention USER] [--no-preview] [--allow-self] [--ephemeral] [--ephemeral-duration DURATION] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send file --to RECIPIENT --file PATH [--pick N] [--caption TEXT] [--filename NAME] [--mime TYPE] [--as auto|document|audio|image|video] [--ptt] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send sticker --to RECIPIENT --file PATH [--pick N] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
 wacli send voice --to RECIPIENT --file PATH [--pick N] [--mime TYPE] [--reply-to MSG_ID] [--reply-to-sender JID] [--post-send-wait 2s]
@@ -30,7 +30,7 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 - If a name matches multiple recipients, interactive terminals prompt.
 - In scripts, use `--pick N` to choose a displayed match.
 - Phone numbers may use common formatting such as `+1 (234) 567-8900`.
-- `send text` rejects the linked account's own phone-number or LID target. WhatsApp may acknowledge these self-DMs without delivering them to Message Yourself, so wacli returns an explicit error instead of `sent: true`.
+- `send text` rejects the linked account's own phone-number or LID target by default. Pass `--allow-self` to explicitly attempt the send. WhatsApp may acknowledge these self-DMs without delivering them to Message Yourself, so `sent: true` still does not confirm device delivery. The flag also works when the send is delegated through a running `sync --follow` process.
 
 ## Replies and reactions
 

--- a/docs/send.md
+++ b/docs/send.md
@@ -31,6 +31,7 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 - In scripts, use `--pick N` to choose a displayed match.
 - Phone numbers may use common formatting such as `+1 (234) 567-8900`.
 - `send text` rejects the linked account's own phone-number or LID target by default. Pass `--allow-self` to explicitly attempt the send. WhatsApp may acknowledge these self-DMs without delivering them to Message Yourself, so `sent: true` still does not confirm device delivery. The flag also works when the send is delegated through a running `sync --follow` process.
+- Restart `sync --follow` after upgrading before using `--allow-self`: an older daemon retains its self-send rejection, which the CLI reports as an error. Upgrading the CLI does not change an already-running daemon.
 
 ## Replies and reactions
 


### PR DESCRIPTION
Adds `send text --allow-self` for an explicit attempt to send to the linked account. The default remains rejection of self recipients, before protocol dispatch, for both direct and delegated sends.

The flag passes through the existing text-send and follow-socket paths. A successful result still means server acknowledgement, not a guarantee that Message Yourself will display it; help and docs state that limitation. Restart `sync --follow` after upgrading to use the opt-in. Older daemons retain their explicit self-send error, and the CLI propagates that failure without a fallback send or false success. This adds no alternate WhatsApp wire protocol or automatic retry policy.

The maintainer update incorporates current main, removes redundant internal helper wrappers, and moves the changelog entry to the final notes PR.

Validation: full local repository gate and independent Codex review through P2; regression coverage for default rejection, opt-in dispatch, flag propagation, and delegation. The real built CLI was also driven through a locked-store Unix socket, verifying that `allow_self` is sent only with the explicit flag. That local check uses a synthetic socket peer.

For actual delivery, the contributor tested build 1f04ec0 against an isolated linked-device store: default rejection, direct opt-in, and delegated opt-in while follow owned the lock. I inspected the linked screenshot, which shows both delivered proof messages. [Live results and screenshot](https://github.com/openclaw/wacli/pull/396#issuecomment-5560814696). This demonstrates that setup; it does not guarantee delivery across all WhatsApp accounts. No new live-account send is claimed for the maintainer update.

Thanks @frdteknikelektro.
