### PR TITLE
fix(release): match changelog versions literally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Release: require the exact version in dated changelog headings before local release preparation.
+
 ## 0.17.2 - 2026-09-05
 
 **Highlights:** more complete searchable message history, bounded backfill retries, and clearer guidance for commands used alongside continuous sync.

--- a/scripts/release-local.mjs
+++ b/scripts/release-local.mjs
@@ -68,7 +68,8 @@ function assertReleaseSource(version, commit, run) {
     throw new Error(`cmd/wacli/root.go does not default to ${version}`);
   }
   const changelog = fs.readFileSync(path.join(repoRoot, "CHANGELOG.md"), "utf8");
-  if (!new RegExp(`^## ${version} - \\d{4}-\\d{2}-\\d{2}$`, "m").test(changelog)) {
+  const datedHeadings = [...changelog.matchAll(/^## (\S+) - \d{4}-\d{2}-\d{2}$/gm)];
+  if (!datedHeadings.some(([, headingVersion]) => headingVersion === version)) {
     throw new Error(`CHANGELOG.md section ${version} must be dated before official preparation`);
   }
 }

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -1,7 +1,18 @@
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync } from 'node:fs';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const root = fileURLToPath(new URL('..', import.meta.url));
 const releaseWorkflow = readFileSync(`${root}/.github/workflows/release.yml`, 'utf8');
@@ -34,4 +45,62 @@ test('shared workflow owns universal assembly and native verification', () => {
   assert.doesNotMatch(darwinConfig, /^universal_binaries:/m);
   assert.equal(existsSync(`${root}/.github/workflows/release-verify.yml`), false);
   assert.doesNotMatch(releaseDocs, /release-local\.mjs|NOTARYTOOL_KEYCHAIN_PROFILE|confirm-gatekeeper-vm/);
+});
+
+test('Darwin preparation requires a literally matching dated changelog heading', async (t) => {
+  const fixture = realpathSync(mkdtempSync(path.join(tmpdir(), 'wacli-release-source-')));
+  t.after(() => rmSync(fixture, { recursive: true, force: true }));
+  cpSync(path.join(root, 'scripts'), path.join(fixture, 'scripts'), { recursive: true });
+  mkdirSync(path.join(fixture, 'cmd/wacli'), { recursive: true });
+  writeFileSync(path.join(fixture, 'cmd/wacli/root.go'), 'const sourceVersion = "0.17.2"\n');
+  const goMod = readFileSync(path.join(root, 'go.mod'), 'utf8');
+  writeFileSync(path.join(fixture, 'go.mod'), goMod);
+  const { prepareDarwinRelease } = await import(
+    pathToFileURL(path.join(fixture, 'scripts/release-local.mjs')).href
+  );
+  const commit = 'a'.repeat(40);
+
+  for (const [name, heading, accepted] of [
+    ['exact dated version', '## 0.17.2 - 2026-09-07', true],
+    ['letter separators', '## 0x17y2 - 2026-09-07', false],
+    ['digit separators', '## 001702 - 2026-09-07', false],
+    ['different version', '## 0.17.3 - 2026-09-07', false],
+    ['undated version', '## 0.17.2', false],
+    ['malformed date', '## 0.17.2 - 2026-9-7', false],
+    ['date format without calendar validation', '## 0.17.2 - 2026-99-99', true],
+  ]) {
+    await t.test(name, () => {
+      writeFileSync(path.join(fixture, 'CHANGELOG.md'), `# Changelog\n\n${heading}\n\n- Fix.\n`);
+      const sourceAccepted = new Error('source validation passed');
+      const executionCalls = [];
+      const run = (command, args, options) => {
+        assert.equal(options.cwd, fixture);
+        if (command === 'git') {
+          if (args[0] === 'status' || args[0] === 'merge-base') return { stdout: '' };
+          if (args[0] === 'rev-parse') return { stdout: commit };
+          if (args[0] === 'show' && args[1] === `${commit}:go.mod`) return { stdout: goMod };
+        }
+        executionCalls.push([command, ...args]);
+        throw sourceAccepted;
+      };
+
+      assert.throws(
+        () => prepareDarwinRelease({
+          tag: 'v0.17.2',
+          commit,
+          outputDir: path.join(fixture, 'candidate'),
+          platform: 'darwin',
+          env: {
+            MAC_RELEASE_CODESIGN_IDENTITY: 'fixture-signing-identity',
+            NOTARYTOOL_KEYCHAIN_PROFILE: 'fixture-notary-profile',
+          },
+          run,
+        }),
+        accepted
+          ? (error) => error === sourceAccepted
+          : /CHANGELOG\.md section 0\.17\.2 must be dated before official preparation/,
+      );
+      assert.deepEqual(executionCalls, accepted ? [['go', 'env', 'GOVERSION']] : []);
+    });
+  }
 });


### PR DESCRIPTION
## Summary

- Recognize dated changelog headings with a fixed pattern, then compare the captured version literally.
- Reject lookalikes such as `0x17y2` and `001702` when preparing `0.17.2`, without changing the existing date-format-only policy.
- Cover the existing `prepareDarwinRelease` entry point with isolated fixtures and an injected command runner; add an Unreleased changelog note.

## Validation

- Red on the original code: both lookalike cases incorrectly passed source validation.
- Green after the fix: all 26 script tests pass, including exact-version acceptance and rejection of lookalikes, wrong versions, undated headings, and malformed dates.
- Full local gate passed: `pnpm format:check`, `pnpm lint`, `pnpm test`, `pnpm build`, and `git diff --check`, using the repository-pinned pnpm and Go toolchain.
- Independent autoreview completed with no accepted findings in its default P0 scope.

Release preparation tests stop at the injected post-validation boundary. No live-account testing, signing, notarization, or release publication was performed. No dependencies, versions, or configuration were changed. Hosted CI and PR review results are separate from this local proof.
