### PR TITLE
fix(sync): bound historical identity startup work

### DIFF
--- a/cmd/wacli/auth.go
+++ b/cmd/wacli/auth.go
@@ -292,7 +292,7 @@ func newAuthLogoutCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {

--- a/cmd/wacli/channels.go
+++ b/cmd/wacli/channels.go
@@ -42,7 +42,7 @@ func newChannelsListCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {
@@ -103,7 +103,7 @@ func newChannelsInfoCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {
@@ -168,7 +168,7 @@ func newChannelsJoinCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {
@@ -222,7 +222,7 @@ func newChannelsLeaveCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {

--- a/cmd/wacli/chats_state.go
+++ b/cmd/wacli/chats_state.go
@@ -131,7 +131,7 @@ func runChatState(flags *rootFlags, opts chatStateOptions, action string, run fu
 	}
 	defer closeApp(a, lk)
 
-	if err := a.EnsureAuthed(); err != nil {
+	if err := a.EnsureAuthed(ctx); err != nil {
 		return err
 	}
 	removePersistenceHandler, err := a.AddChatStatePersistenceHandler(ctx)

--- a/cmd/wacli/contacts_check.go
+++ b/cmd/wacli/contacts_check.go
@@ -94,7 +94,7 @@ func runContactsCheck(flags *rootFlags, args []string) error {
 	}
 	defer closeApp(a, lk)
 
-	if err := a.EnsureAuthed(); err != nil {
+	if err := a.EnsureAuthed(ctx); err != nil {
 		return err
 	}
 	if err := a.Connect(ctx, false, nil); err != nil {

--- a/cmd/wacli/groups_admin.go
+++ b/cmd/wacli/groups_admin.go
@@ -44,7 +44,7 @@ func newGroupsCreateCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {
@@ -121,7 +121,7 @@ func newGroupsTopicCmd(flags *rootFlags, use string) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {
@@ -188,7 +188,7 @@ func newGroupsToggleCmd(flags *rootFlags, use, short string, apply func(context.
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {
@@ -272,7 +272,7 @@ func newGroupsRequestsListCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {
@@ -324,7 +324,7 @@ func newGroupsRequestsActionCmd(flags *rootFlags, action string) *cobra.Command 
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {

--- a/cmd/wacli/groups_info_rename.go
+++ b/cmd/wacli/groups_info_rename.go
@@ -33,7 +33,7 @@ func newGroupsInfoCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {
@@ -101,7 +101,7 @@ func newGroupsRenameCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {
@@ -151,7 +151,7 @@ func newGroupsLeaveCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {

--- a/cmd/wacli/groups_invite_join.go
+++ b/cmd/wacli/groups_invite_join.go
@@ -48,7 +48,7 @@ func newGroupsInviteLinkGetCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {
@@ -94,7 +94,7 @@ func newGroupsInviteLinkRevokeCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {
@@ -140,7 +140,7 @@ func newGroupsJoinCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {

--- a/cmd/wacli/groups_participants.go
+++ b/cmd/wacli/groups_participants.go
@@ -46,7 +46,7 @@ func newGroupsParticipantsActionCmd(flags *rootFlags, action string) *cobra.Comm
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {

--- a/cmd/wacli/groups_refresh_list.go
+++ b/cmd/wacli/groups_refresh_list.go
@@ -28,7 +28,7 @@ func newGroupsRefreshCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {

--- a/cmd/wacli/media.go
+++ b/cmd/wacli/media.go
@@ -66,7 +66,7 @@ func newMediaRetryCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {
@@ -155,7 +155,7 @@ func newMediaBackfillCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {
@@ -254,7 +254,7 @@ func newMediaDownloadCmd(flags *rootFlags) *cobra.Command {
 			defer closeApp(a, lk)
 
 			if !readOnly {
-				if err := a.EnsureAuthed(); err != nil {
+				if err := a.EnsureAuthed(ctx); err != nil {
 					return err
 				}
 			}

--- a/cmd/wacli/messages.go
+++ b/cmd/wacli/messages.go
@@ -502,7 +502,7 @@ func newMessagesDeleteCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			msg, chatJID, err := loadMessageMutationTarget(ctx, a, chat, id)
@@ -623,7 +623,7 @@ func newMessagesRevokeCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			msg, chatJID, found, err := loadMessageRevokeTarget(ctx, a, chat, id)
@@ -726,7 +726,7 @@ func newMessagesEditCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			msg, chatJID, err := loadMessageMutationTarget(ctx, a, chat, id)
@@ -801,7 +801,7 @@ func newMessagesForwardCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			source, _, err := loadMessageMutationTarget(ctx, a, chat, id)

--- a/cmd/wacli/poll_cmd.go
+++ b/cmd/wacli/poll_cmd.go
@@ -90,7 +90,7 @@ func newPollVoteCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			toJID, err := resolveRecipient(a, to, recipientOptions{pick: pick, asJSON: flags.asJSON})

--- a/cmd/wacli/presence.go
+++ b/cmd/wacli/presence.go
@@ -83,7 +83,7 @@ func runPresence(flags *rootFlags, to string, state types.ChatPresence, media st
 	}
 	defer closeApp(a, lk)
 
-	if err := a.EnsureAuthed(); err != nil {
+	if err := a.EnsureAuthed(ctx); err != nil {
 		return err
 	}
 	if err := a.Connect(ctx, false, nil); err != nil {

--- a/cmd/wacli/profile.go
+++ b/cmd/wacli/profile.go
@@ -65,7 +65,7 @@ func newProfileSetPictureCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {
@@ -301,7 +301,7 @@ func openLiveProfileApp(flags *rootFlags, needLock bool) (context.Context, conte
 		cancel()
 		return nil, nil, nil, nil, err
 	}
-	if err := a.EnsureAuthed(); err != nil {
+	if err := a.EnsureAuthed(ctx); err != nil {
 		cancel()
 		closeApp(a, lk)
 		return nil, nil, nil, nil, err

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -106,7 +106,7 @@ func newSendTextCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 

--- a/cmd/wacli/send_file_cmd.go
+++ b/cmd/wacli/send_file_cmd.go
@@ -72,7 +72,7 @@ func newSendFileCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 

--- a/cmd/wacli/send_location_cmd.go
+++ b/cmd/wacli/send_location_cmd.go
@@ -90,7 +90,7 @@ func newSendLocationCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			toJID, err := resolveRecipient(a, to, recipientOptions{pick: pick, asJSON: flags.asJSON})

--- a/cmd/wacli/send_poll_cmd.go
+++ b/cmd/wacli/send_poll_cmd.go
@@ -79,7 +79,7 @@ func newSendPollCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			toJID, err := resolveRecipient(a, to, recipientOptions{pick: pick, asJSON: flags.asJSON})

--- a/cmd/wacli/send_react_cmd.go
+++ b/cmd/wacli/send_react_cmd.go
@@ -56,7 +56,7 @@ func newSendReactCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {

--- a/cmd/wacli/send_select_cmd.go
+++ b/cmd/wacli/send_select_cmd.go
@@ -120,7 +120,7 @@ func newSendSelectCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			toJID, err := resolveRecipient(a, to, recipientOptions{pick: pick, asJSON: flags.asJSON})

--- a/cmd/wacli/send_status_cmd.go
+++ b/cmd/wacli/send_status_cmd.go
@@ -69,7 +69,7 @@ func newSendStatusCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 			if err := a.Connect(ctx, false, nil); err != nil {

--- a/cmd/wacli/send_sticker_cmd.go
+++ b/cmd/wacli/send_sticker_cmd.go
@@ -58,7 +58,7 @@ func newSendStickerCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 

--- a/cmd/wacli/send_voice_cmd.go
+++ b/cmd/wacli/send_voice_cmd.go
@@ -60,7 +60,7 @@ func newSendVoiceCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 

--- a/cmd/wacli/sync.go
+++ b/cmd/wacli/sync.go
@@ -74,7 +74,7 @@ func newSyncCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			if err := a.EnsureAuthed(); err != nil {
+			if err := a.EnsureAuthed(ctx); err != nil {
 				return err
 			}
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -4,6 +4,8 @@ Read when: running continuous capture, one-shot sync, contact/group refresh, or 
 
 `wacli sync` requires an existing authenticated store and never displays a QR code. It captures WhatsApp Web events into the local SQLite store.
 
+Startup repairs historical LID identities using indexed message lookups without rebuilding unchanged search content. Interrupting startup stops identity repair between individual identities; the next run resumes any remaining repairs.
+
 ## Command
 
 ```bash
@@ -22,7 +24,6 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-t
 - `--download-media` runs a bounded media downloader for sync events. Clean one-shot and bootstrap runs finish queued downloads before exiting; cancellation, errors, and storage-limit exits stop immediately.
 - `--send-spacing DURATION|MIN-MAX` paces serialized sends delegated to a running follow process. A single duration such as `2s` sets a fixed minimum gap; a range such as `500ms-5s` chooses a fresh random gap for each send. It is disabled by default, so unset behavior remains unchanged. The caller's command timeout includes time queued behind earlier sends, pacing, and the send itself; a request that runs out of time is not dispatched.
 - `--refresh-contacts` imports contacts from the session store.
-- Startup repairs historical LID identities using indexed message lookups without rebuilding unchanged search content. Interrupting startup stops identity repair between individual identities; the next run resumes any remaining repairs.
 - `--refresh-groups` fetches joined groups live and updates the local DB.
 - `--refresh-channels` fetches subscribed WhatsApp Channels live and updates local chat rows.
 - `--webhook URL` posts successfully stored live message events as JSON on a bounded background worker. The payload includes `ChatName` when a locally resolved chat name is available.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -22,6 +22,7 @@ wacli sync [--once] [--follow] [--idle-exit 30s] [--max-reconnect 5m] [--stale-t
 - `--download-media` runs a bounded media downloader for sync events. Clean one-shot and bootstrap runs finish queued downloads before exiting; cancellation, errors, and storage-limit exits stop immediately.
 - `--send-spacing DURATION|MIN-MAX` paces serialized sends delegated to a running follow process. A single duration such as `2s` sets a fixed minimum gap; a range such as `500ms-5s` chooses a fresh random gap for each send. It is disabled by default, so unset behavior remains unchanged. The caller's command timeout includes time queued behind earlier sends, pacing, and the send itself; a request that runs out of time is not dispatched.
 - `--refresh-contacts` imports contacts from the session store.
+- Startup repairs historical LID identities using indexed message lookups without rebuilding unchanged search content. Interrupting startup stops identity repair between individual identities; the next run resumes any remaining repairs.
 - `--refresh-groups` fetches joined groups live and updates the local DB.
 - `--refresh-channels` fetches subscribed WhatsApp Channels live and updates local chat rows.
 - `--webhook URL` posts successfully stored live message events as JSON on a bounded background worker. The payload includes `ChatName` when a locally resolved chat name is available.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -195,7 +195,10 @@ func (a *App) Close() {
 	}
 }
 
-func (a *App) EnsureAuthed() error {
+func (a *App) EnsureAuthed(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := a.OpenWA(); err != nil {
 		return err
 	}
@@ -203,7 +206,7 @@ func (a *App) EnsureAuthed() error {
 		if a.opts.ReadOnly {
 			return nil
 		}
-		return a.migrateHistoricalLIDs(context.Background())
+		return a.migrateHistoricalLIDs(ctx)
 	}
 	return fmt.Errorf("not authenticated; run `wacli auth`")
 }

--- a/internal/app/backfill.go
+++ b/internal/app/backfill.go
@@ -62,7 +62,7 @@ func (a *App) BackfillHistory(ctx context.Context, opts BackfillOptions) (Backfi
 		return BackfillResult{}, err
 	}
 
-	if err := a.EnsureAuthed(); err != nil {
+	if err := a.EnsureAuthed(ctx); err != nil {
 		return BackfillResult{}, err
 	}
 	if err := a.OpenWA(); err != nil {

--- a/internal/app/lid_migration.go
+++ b/internal/app/lid_migration.go
@@ -18,11 +18,17 @@ func (a *App) migrateHistoricalLIDs(ctx context.Context) error {
 		return fmt.Errorf("load historical LID rows: %w", err)
 	}
 	for _, raw := range lids {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		lid, err := types.ParseJID(strings.TrimSpace(raw))
 		if err != nil || lid.Server != types.HiddenUserServer {
 			continue
 		}
 		pn := a.wa.ResolveLIDToPN(ctx, lid)
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if pn.IsEmpty() || pn.Server != types.DefaultUserServer {
 			continue
 		}

--- a/internal/app/lid_migration_test.go
+++ b/internal/app/lid_migration_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +11,33 @@ import (
 	"github.com/openclaw/wacli/internal/store"
 	"go.mau.fi/whatsmeow/types"
 )
+
+type cancelingLIDResolver struct {
+	WAClient
+	cancel context.CancelFunc
+}
+
+func (f cancelingLIDResolver) ResolveLIDToPN(ctx context.Context, jid types.JID) types.JID {
+	f.cancel()
+	return types.JID{User: "15550000001", Server: types.DefaultUserServer}
+}
+
+func TestEnsureAuthedStopsHistoricalMigrationOnCancellation(t *testing.T) {
+	a := newTestApp(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	a.wa = cancelingLIDResolver{WAClient: newFakeWA(), cancel: cancel}
+	if err := a.db.UpsertChat("123@lid", "dm", "Synthetic", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.EnsureAuthed(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("EnsureAuthed = %v, want context.Canceled", err)
+	}
+	lids, err := a.db.HistoricalLIDJIDs()
+	if err != nil || len(lids) != 1 || lids[0] != "123@lid" {
+		t.Fatalf("canceled migration changed historical identities: %v, %v", lids, err)
+	}
+}
 
 func TestEnsureAuthedMigratesHistoricalLIDs(t *testing.T) {
 	a := newTestApp(t)
@@ -34,7 +63,7 @@ func TestEnsureAuthedMigratesHistoricalLIDs(t *testing.T) {
 		t.Fatalf("UpsertMessage lid: %v", err)
 	}
 
-	if err := a.EnsureAuthed(); err != nil {
+	if err := a.EnsureAuthed(t.Context()); err != nil {
 		t.Fatalf("EnsureAuthed: %v", err)
 	}
 
@@ -87,7 +116,7 @@ func TestEnsureAuthedRemovesPurgedAliasMediaBeforeLIDMigration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := a.EnsureAuthed(); err != nil {
+	if err := a.EnsureAuthed(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(aliasPath); !os.IsNotExist(err) {
@@ -133,7 +162,7 @@ func TestEnsureAuthedPreservesDuplicateAliasMediaForLaterPurge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := a.EnsureAuthed(); err != nil {
+	if err := a.EnsureAuthed(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(lidPath); err != nil {
@@ -187,7 +216,7 @@ func TestEnsureAuthedPreservesAliasMediaWhenDestinationPathIsStale(t *testing.T)
 		t.Fatal(err)
 	}
 
-	if err := a.EnsureAuthed(); err != nil {
+	if err := a.EnsureAuthed(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(lidPath); err != nil {
@@ -234,7 +263,7 @@ func TestEnsureAuthedKeepsMediaWhenDuplicatePathsIdentifySameFile(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	if err := a.EnsureAuthed(); err != nil {
+	if err := a.EnsureAuthed(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(mediaPath); err != nil {
@@ -260,7 +289,7 @@ func TestEnsureAuthedLeavesUnresolvedHistoricalLIDs(t *testing.T) {
 		t.Fatalf("UpsertChat lid: %v", err)
 	}
 
-	if err := a.EnsureAuthed(); err != nil {
+	if err := a.EnsureAuthed(t.Context()); err != nil {
 		t.Fatalf("EnsureAuthed: %v", err)
 	}
 	lids, err := a.db.HistoricalLIDJIDs()
@@ -296,7 +325,7 @@ func TestEnsureAuthedSkipsHistoricalLIDMigrationReadOnly(t *testing.T) {
 	f.lids[lid.ToNonAD()] = pn
 	reader.wa = f
 
-	if err := reader.EnsureAuthed(); err != nil {
+	if err := reader.EnsureAuthed(t.Context()); err != nil {
 		t.Fatalf("EnsureAuthed read-only: %v", err)
 	}
 	lids, err := reader.db.HistoricalLIDJIDs()

--- a/internal/store/identity_fts_test.go
+++ b/internal/store/identity_fts_test.go
@@ -1,0 +1,88 @@
+//go:build sqlite_fts5
+
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMessageIdentityUpdatesDoNotRewriteFTS(t *testing.T) {
+	db := openTestDB(t)
+	db.sql.SetMaxOpenConns(1)
+	if err := db.UpsertChat("100@g.us", "group", "Synthetic", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID: "100@g.us", MsgID: "identity", SenderJID: "123@lid",
+		Timestamp: time.Now(), Text: "searchable needle",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var before, after int
+	if err := db.sql.QueryRow(`SELECT total_changes()`).Scan(&before); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.sql.Exec(`UPDATE messages SET sender_jid = ?, quoted_sender_jid = ? WHERE msg_id = ?`,
+		"15550000001@s.whatsapp.net", "15550000002@s.whatsapp.net", "identity"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.sql.QueryRow(`SELECT total_changes()`).Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if writes := after - before; writes != 1 {
+		t.Fatalf("identity-only update wrote %d rows, want only the message row", writes)
+	}
+	msgs, err := db.SearchMessages(SearchMessagesParams{Query: "needle", Limit: 10})
+	if err != nil || len(msgs) != 1 || msgs[0].SenderJID != "15550000001@s.whatsapp.net" {
+		t.Fatalf("search after identity update: %+v, %v", msgs, err)
+	}
+}
+
+func TestSelectiveFTSUpdatesPreserveSearchLifecycle(t *testing.T) {
+	db := openTestDB(t)
+	if err := db.UpsertChat("100@g.us", "group", "Synthetic", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertMessage(UpsertMessageParams{
+		ChatJID: "100@g.us", MsgID: "lifecycle", Timestamp: time.Now(), Text: "original",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, column := range []string{"text", "media_caption", "filename", "chat_name", "sender_name", "display_text"} {
+		t.Run(column, func(t *testing.T) {
+			if _, err := db.sql.Exec(`UPDATE messages SET ` + column + ` = 'replacement'`); err != nil {
+				t.Fatal(err)
+			}
+			msgs, err := db.SearchMessages(SearchMessagesParams{Query: "replacement", Limit: 10})
+			if err != nil || len(msgs) != 1 {
+				t.Fatalf("search updated %s: %+v, %v", column, msgs, err)
+			}
+			if _, err := db.sql.Exec(`UPDATE messages SET ` + column + ` = NULL`); err != nil {
+				t.Fatal(err)
+			}
+			msgs, err = db.SearchMessages(SearchMessagesParams{Query: "replacement", Limit: 10})
+			if err != nil || len(msgs) != 0 {
+				t.Fatalf("search cleared %s: %+v, %v", column, msgs, err)
+			}
+		})
+	}
+	for _, step := range []struct {
+		query string
+		want  int
+	}{
+		{`UPDATE messages SET text = 'retained'`, 1},
+		{`UPDATE messages SET rowid = rowid + 100`, 1},
+		{`UPDATE messages SET deleted_at = 1`, 0},
+		{`UPDATE messages SET deleted_at = NULL`, 1},
+		{`DELETE FROM messages`, 0},
+	} {
+		if _, err := db.sql.Exec(step.query); err != nil {
+			t.Fatal(err)
+		}
+		msgs, err := db.SearchMessages(SearchMessagesParams{Query: "retained", Limit: 10})
+		if err != nil || len(msgs) != step.want {
+			t.Fatalf("%s: search = %+v, %v", step.query, msgs, err)
+		}
+	}
+}

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -39,6 +39,21 @@ var schemaMigrations = []migration{
 	{version: 23, name: "app state recovery markers", up: migrateAppStateRecoveryMarkers},
 	{version: 24, name: "app state recovery intents", up: migrateAppStateRecoveryIntents},
 	{version: 25, name: "message locations", up: migrateMessageLocations},
+	{version: 26, name: "message identity indexes and selective fts updates", up: migrateMessageIdentityIndexes},
+}
+
+func migrateMessageIdentityIndexes(d *DB) error {
+	hasMessages, err := d.tableExists("messages")
+	if err != nil || !hasMessages {
+		return err
+	}
+	if _, err := d.sql.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_messages_sender_jid ON messages(sender_jid);
+		CREATE INDEX IF NOT EXISTS idx_messages_quoted_sender_jid ON messages(quoted_sender_jid);
+	`); err != nil {
+		return fmt.Errorf("create message identity indexes: %w", err)
+	}
+	return migrateMessagesFTS(d)
 }
 
 func migrateMessageLocations(d *DB) error {
@@ -800,7 +815,16 @@ func migrateMessagesFTS(d *DB) error {
 			DELETE FROM messages_fts WHERE rowid = old.rowid;
 		END;
 
-		CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
+		CREATE TRIGGER messages_au AFTER UPDATE ON messages
+		WHEN old.rowid IS NOT new.rowid
+			OR old.deleted_at IS NOT new.deleted_at
+			OR old.text IS NOT new.text
+			OR old.media_caption IS NOT new.media_caption
+			OR old.filename IS NOT new.filename
+			OR old.chat_name IS NOT new.chat_name
+			OR old.sender_name IS NOT new.sender_name
+			OR old.display_text IS NOT new.display_text
+		BEGIN
 			DELETE FROM messages_fts WHERE rowid = old.rowid;
 			INSERT INTO messages_fts(rowid, text, media_caption, filename, chat_name, sender_name, display_text)
 			SELECT new.rowid, COALESCE(new.text,''), COALESCE(new.media_caption,''), COALESCE(new.filename,''), COALESCE(new.chat_name,''), COALESCE(new.sender_name,''), COALESCE(new.display_text,'')


### PR DESCRIPTION
Historical LID repair ran before sync connected using a background context. For each identity it scanned all messages by sender and quoted sender, and its identity-only updates deleted and reinserted unchanged FTS rows. Large upgrades could therefore spend a long time silently in startup and continue after the first shutdown signal.

This change indexes both identity columns, refreshes FTS only when indexed content, row identity, or deletion state actually changes, and propagates each command's context into historical repair. Cancellation stops between identities and after resolution, while committed repairs remain resumable. The internal authentication method now requires its caller's context; the command-line interface is unchanged.

Fixes #395.

Proof on an isolated synthetic store with the reported 59,395-message/909-chat scale and 2,909 identity mappings:

- Real built CLI, with external transport blocked by a loopback proxy: the previous binary logged SIGTERM but required SIGKILL after three seconds; the candidate exited in 16 ms. Both retained every message and passed SQLite integrity checks.
- Historical repair completed in an observed 6.15 seconds after the change versus 67.4 seconds before on this busy host. These are diagnostic timings, not a controlled benchmark.
- A regression run using the original migration code failed because an identity-only update wrote 11 rows; the candidate writes only the message row. Search regressions cover all indexed fields, NULL transitions, rowid changes, tombstones, restoration, and deletion. Cancellation coverage preserves unprocessed identities.

Validation includes the full local repository gate and independent Codex autoreview through P2. The reporter's original Linux store was unavailable; the before/after shutdown behavior was reproduced with synthetic data on macOS. No real account, session keys, messages, or WhatsApp traffic were used.

The changelog entry is reserved for the final consolidated notes PR. Thanks @amitav13 for the detailed upgrade report.
