### PR TITLE
chore: prepare 0.18.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.18.0 - 2026-09-07
 
 **Highlights:** faster, interruptible upgrades, offline group rosters, and explicit opt-in self-chat sends.
 


### PR DESCRIPTION
Finalize the prepared 0.18.0 changelog for September 7, preserving its Highlights line and user-facing ordering. The source version already reports 0.18.0.

The full local repository gate and independent review pass. Publication will use the existing Go CLI release workflow only after the protected-main release commit has green CI.
