### PR TITLE
fix(send): cap ffmpeg voice waveform PCM stdout

### DIFF
--- a/cmd/wacli/send_file.go
+++ b/cmd/wacli/send_file.go
@@ -36,6 +36,8 @@ const imageThumbnailMaxDimension = 96
 const imageThumbnailMaxPixels = 40_000_000
 const voiceWaveformSamples = 64
 const voiceWaveformMax = 100
+const voiceWaveformSampleRate = 8000
+const maxWaveformPCMBytes = 2 << 20 // 2 MiB of 8 kHz s16le is ~131s of PCM
 
 const sendMediaTypeAuto = "auto"
 
@@ -510,16 +512,29 @@ func probeAudioWaveform(ctx context.Context, filePath string) []byte {
 	probeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	out, err := exec.CommandContext(probeCtx, "ffmpeg",
+	probeSeconds := float64(maxWaveformPCMBytes) / float64(voiceWaveformSampleRate*2)
+	cmd := exec.CommandContext(probeCtx, "ffmpeg",
 		"-v", "error",
 		"-i", filePath,
+		"-t", strconv.FormatFloat(probeSeconds, 'f', 3, 64),
 		"-ac", "1",
-		"-ar", "8000",
+		"-ar", strconv.Itoa(voiceWaveformSampleRate),
 		"-f", "s16le",
 		"-acodec", "pcm_s16le",
+		"-fs", strconv.Itoa(maxWaveformPCMBytes),
 		"-",
-	).Output()
+	)
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
+		return nil
+	}
+	if err := cmd.Start(); err != nil {
+		return nil
+	}
+	out, err := io.ReadAll(io.LimitReader(stdout, int64(maxWaveformPCMBytes)))
+	cancel()
+	_ = cmd.Wait()
+	if err != nil || len(out) == 0 {
 		return nil
 	}
 	return waveformFromPCM16LE(out)

--- a/cmd/wacli/send_file.go
+++ b/cmd/wacli/send_file.go
@@ -532,9 +532,14 @@ func probeAudioWaveform(ctx context.Context, filePath string) []byte {
 		return nil
 	}
 	out, err := io.ReadAll(io.LimitReader(stdout, int64(maxWaveformPCMBytes)))
-	cancel()
-	_ = cmd.Wait()
-	if err != nil || len(out) == 0 {
+	reachedLimit := len(out) == maxWaveformPCMBytes
+	if reachedLimit {
+		cancel()
+	}
+	waitErr := cmd.Wait()
+	// Killing the decoder at the byte limit is expected; other failures must
+	// not turn a partial decode into a valid waveform.
+	if err != nil || len(out) == 0 || (!reachedLimit && waitErr != nil) {
 		return nil
 	}
 	return waveformFromPCM16LE(out)

--- a/cmd/wacli/send_file_test.go
+++ b/cmd/wacli/send_file_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -349,6 +351,91 @@ func TestProbeAudioMetadataWithFFmpeg(t *testing.T) {
 	if !hasNonZero {
 		t.Fatalf("waveform is all zero")
 	}
+}
+
+// Keep in sync with maxWaveformPCMBytes.
+const testWaveformPCMCap = 2 << 20
+
+func TestProbeAudioWaveformCapsFFmpegStdout(t *testing.T) {
+	installFakeFFmpegPCMWriter(t, testWaveformPCMCap, testWaveformPCMCap*2)
+
+	input := filepath.Join(t.TempDir(), "voice.ogg")
+	if err := os.WriteFile(input, []byte("placeholder"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := probeAudioWaveform(context.Background(), input)
+	full := patternedWaveformPCM(testWaveformPCMCap, testWaveformPCMCap*2)
+	want := waveformFromPCM16LE(full[:testWaveformPCMCap])
+	uncapped := waveformFromPCM16LE(full)
+	if bytes.Equal(want, uncapped) {
+		t.Fatal("fixture prefix and full PCM produce the same waveform")
+	}
+	if bytes.Equal(got, uncapped) {
+		t.Fatalf("waveform matches uncapped %d-byte PCM; ffmpeg stdout was not capped", len(full))
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("waveform = %v, want prefix of %d bytes", got, testWaveformPCMCap)
+	}
+}
+
+func patternedWaveformPCM(prefix, total int) []byte {
+	buf := make([]byte, total)
+	for i := 0; i < prefix; i += 2 {
+		binary.LittleEndian.PutUint16(buf[i:i+2], 100)
+	}
+	for i := prefix; i < total; i += 2 {
+		binary.LittleEndian.PutUint16(buf[i:i+2], 10000)
+	}
+	return buf
+}
+
+func installFakeFFmpegPCMWriter(t *testing.T, prefix, total int) {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "main.go")
+	program := `package main
+
+import (
+	"encoding/binary"
+	"os"
+	"strconv"
+)
+
+func main() {
+	prefix, _ := strconv.Atoi(os.Getenv("FAKE_FFMPEG_PREFIX"))
+	total, _ := strconv.Atoi(os.Getenv("FAKE_FFMPEG_TOTAL"))
+	if prefix <= 0 || total < prefix || total%2 != 0 || prefix%2 != 0 {
+		os.Exit(2)
+	}
+	buf := make([]byte, total)
+	for i := 0; i < prefix; i += 2 {
+		binary.LittleEndian.PutUint16(buf[i:i+2], 100)
+	}
+	for i := prefix; i < total; i += 2 {
+		binary.LittleEndian.PutUint16(buf[i:i+2], 10000)
+	}
+	_, _ = os.Stdout.Write(buf)
+}
+`
+	if err := os.WriteFile(src, []byte(program), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module fakefmpeg\n\ngo 1.22\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "ffmpeg")
+	if runtime.GOOS == "windows" {
+		out += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", out, src)
+	build.Dir = dir
+	if b, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build fake ffmpeg: %v\n%s", err, b)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_FFMPEG_PREFIX", strconv.Itoa(prefix))
+	t.Setenv("FAKE_FFMPEG_TOTAL", strconv.Itoa(total))
 }
 
 func TestAttachSendFileReplyContext(t *testing.T) {

--- a/cmd/wacli/send_file_test.go
+++ b/cmd/wacli/send_file_test.go
@@ -379,6 +379,25 @@ func TestProbeAudioWaveformCapsFFmpegStdout(t *testing.T) {
 	}
 }
 
+func TestProbeAudioWaveformShortDecodeExitStatus(t *testing.T) {
+	for _, exitCode := range []int{0, 1} {
+		t.Run(strconv.Itoa(exitCode), func(t *testing.T) {
+			installFakeFFmpegPCMWriter(t, 512, 1024)
+			t.Setenv("FAKE_FFMPEG_EXIT", strconv.Itoa(exitCode))
+			got := probeAudioWaveform(context.Background(), "voice.ogg")
+			if exitCode != 0 {
+				if got != nil {
+					t.Fatal("failed decoder returned a waveform from partial PCM")
+				}
+				return
+			}
+			if want := waveformFromPCM16LE(patternedWaveformPCM(512, 1024)); !bytes.Equal(got, want) {
+				t.Fatalf("short waveform = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
 func patternedWaveformPCM(prefix, total int) []byte {
 	buf := make([]byte, total)
 	for i := 0; i < prefix; i += 2 {
@@ -416,6 +435,8 @@ func main() {
 		binary.LittleEndian.PutUint16(buf[i:i+2], 10000)
 	}
 	_, _ = os.Stdout.Write(buf)
+	exitCode, _ := strconv.Atoi(os.Getenv("FAKE_FFMPEG_EXIT"))
+	os.Exit(exitCode)
 }
 `
 	if err := os.WriteFile(src, []byte(program), 0o600); err != nil {

--- a/docs/send.md
+++ b/docs/send.md
@@ -110,6 +110,7 @@ wacli polls list [--chat RECIPIENT] [--limit N] [--json]
 - `send voice` is a shortcut for `send file --ptt`.
 - Voice notes require OGG/Opus audio (`audio/ogg; codecs=opus`).
 - When available, `ffprobe` sets voice-note duration and `ffmpeg` generates the 64-sample waveform from decoded PCM audio.
+- Waveform decoding is capped at 2 MiB (about 131 seconds). Longer voice notes use that initial segment for the waveform; the complete audio file and its full duration are still sent. Failed decodes omit the optional waveform.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Voice-note waveform generation buffered the entire ffmpeg PCM decode even though the source upload was limited to 100 MiB. A long compressed recording could therefore allocate far more memory than its file size suggests.

Bound the decode to 2 MiB of 8 kHz mono PCM (about 131 seconds), stop and reap ffmpeg at the limit, and retain its failure status for shorter decodes. The complete audio and independently probed duration are unchanged. Document that long-note waveforms describe the initial segment. Thanks @SebTardif for the fix and oversized-output regression.

## Validation

- Full local gate: docs generation, formatting, vet, plain and FTS suites, Windows lock cross-compile, CGO-required check, docs/release tests, build, and whitespace check.
- The new short-decode regression fails on the original PR head because partial PCM from a decoder exiting 1 becomes a waveform; it passes after the maintainer repair. Short successful decodes and oversized output also pass.
- Real ffmpeg/ffprobe integration: built the production CLI sources with a temporary offline entrypoint calling `loadVoiceNoteMetadata` directly. The production probe and decoder were unchanged; no mocked decoder or WhatsApp transport was used for this run.
- A 300-second synthetic Opus file (1,310,463 bytes), silent for the first 140 seconds, produced a nonzero full-file waveform on main and a 64-sample silent-prefix waveform after the fix. Both reported the same 301-second rounded duration. Go allocations for the probe fell from 16,972,352 to 4,862,768 bytes in this run; timing and allocation figures are fixture-specific.
- A 0.7-second tone retained its nonzero 64-sample waveform and one-second duration. Invalid input omitted the waveform. All four real ffmpeg children were reaped.
- The ordinary built CLI was also exercised with version, help, and isolated-store commands.

This proves local waveform generation and child cleanup. No WhatsApp message was sent; recipient rendering was not tested. Changelog context is in the final notes PR to keep sibling branches independent.
