### PR TITLE
chore: prepare 0.18.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Highlights:** bounded memory use when generating waveforms for long voice notes.
+
+- Send: cap voice-note waveform decoding at 2 MiB (about 131 seconds), preserve full audio and duration, and omit partial waveforms when ffmpeg fails. (#402 - thanks @SebTardif)
+
 ## 0.18.0 - 2026-09-07
 
 **Highlights:** faster, interruptible upgrades, offline group rosters, and explicit opt-in self-chat sends.

--- a/cmd/wacli/root.go
+++ b/cmd/wacli/root.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const sourceVersion = "0.18.0"
+const sourceVersion = "0.18.1"
 
 var version string
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -19,7 +19,7 @@ wacli uses the fleet-standard reusable Go CLI workflow from `openclaw/release-wo
 ## Dispatch
 
 ```bash
-gh workflow run release.yml --repo openclaw/wacli --ref main -f version=0.18.0
+gh workflow run release.yml --repo openclaw/wacli --ref main -f version=0.18.1
 ```
 
 Watch the exact run through completion. A successful run is not sufficient on its own: verify the public release is non-draft and non-prerelease, its tag peels to the frozen protected-main commit, every expected asset is present, `checksums.txt` validates the downloaded assets, both native macOS verifier jobs passed, the Homebrew update run succeeded, and the closeout PR was opened.


### PR DESCRIPTION
Prepare the 0.18.1 patch after #402: record its bounded voice-waveform decode and failure handling, preserve contributor credit, and advance the source version and release example.

Merge #402 first, then this PR. This is the only changelog edit in this batch. No tag or release is created here.

Dependency recheck found direct runtime modules, pnpm, and pinned Actions current. CEL 0.32.0 cannot replace 0.31.0: its module declares the new cel.dev/cel-go path while sqlc still imports github.com/google/cel-go. Newly published pgx 5.11.0 and the September 8 TiDB parser revision are held for a later refresh. No module or checksum changes are included.

Validation: full local repository gate, docs generation, built CLI version output, isolated-store CLI smoke, and clean independent review. Release remains gated on both PRs merging, CI on the resulting main commit, dated release notes, and the standard signed/notarized artifact and Homebrew workflow.
