### PR TITLE
chore: release 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.18.1 - 2026-09-07
 
 **Highlights:** bounded memory use when generating waveforms for long voice notes.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -42,8 +42,8 @@ CGO_ENABLED=1 CGO_CFLAGS="-Wno-error=missing-braces" \
 
 For local development:
 
-Install Node.js 24 or newer and the pnpm version pinned in `package.json`
-(currently 11.25.0). Corepack users can run `corepack pnpm install --frozen-lockfile`
+Install Node.js 24 or newer and the pnpm version pinned in `package.json`.
+Corepack users can run `corepack pnpm install --frozen-lockfile`
 from the checkout to download and verify that pinned version.
 
 ```bash


### PR DESCRIPTION
Prepare the authorized 0.18.1 patch release for bounded voice-note waveform decoding.

Date the existing Highlights and fix entry as September 7, 2026. The source version already reports 0.18.1. Remove a stale hardcoded pnpm version from installation instructions so package.json remains the source of truth.

Validation: full local formatting, vet, plain/FTS tests, Windows lock cross-compile, CGO-required and docs/release tests, docs generation, build, whitespace checks, and `wacli --version` → `wacli 0.18.1`. Independent review is clean. The release workflow will run only after CI passes on the merged release commit.
