### PR TITLE
sync: apply incoming edits delivered as SecretEncryptedMessage

### DIFF
--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -547,6 +547,11 @@ func (a *App) handleLiveSyncMessage(ctx context.Context, opts SyncOptions, v *ev
 	if pm.ReactionToID != "" && pm.ReactionEmoji == "" && v.Message != nil && v.Message.GetEncReactionMessage() != nil {
 		a.decryptEncryptedReaction(ctx, &pm, v)
 	}
+	if a.decryptSecretEncryptedEdit(ctx, &pm, v) {
+		// The envelope carries no content of its own: everything worth storing
+		// came from the decrypted edit, already merged onto the original id.
+		pm.UnhandledPayload = ""
+	}
 	incrementUnread := a.shouldIncrementLiveUnread(ctx, pm)
 	if err := a.storeParsedMessageForSync(ctx, pm, limits...); err == nil {
 		if incrementUnread {
@@ -816,6 +821,60 @@ func (a *App) decryptEncryptedReaction(ctx context.Context, pm *wa.ParsedMessage
 			pm.ReactionToID = key.GetID()
 		}
 	}
+}
+
+// decryptSecretEncryptedEdit applies an incoming message edit that arrives
+// wrapped in a SecretEncryptedMessage envelope, and reports whether it did.
+//
+// An edit is not delivered as a bare ProtocolMessage: the server sends a
+// SecretEncryptedMessage whose SecretEncType is MESSAGE_EDIT and whose
+// TargetMessageKey points at the original. Only POLL_ADD_OPTION was decrypted,
+// so an edit was stored as a second content-less row while the original kept
+// its superseded text. That is worse than a visible gap: a reader gets stale
+// content that looks valid, with nothing marking it as outdated.
+func (a *App) decryptSecretEncryptedEdit(ctx context.Context, pm *wa.ParsedMessage, msg *events.Message) bool {
+	if pm == nil || msg == nil {
+		return false
+	}
+	secret := msg.Message.GetSecretEncryptedMessage()
+	if secret.GetSecretEncType() != waE2E.SecretEncryptedMessage_MESSAGE_EDIT {
+		return false
+	}
+	target := strings.TrimSpace(secret.GetTargetMessageKey().GetID())
+	if target == "" {
+		return false
+	}
+
+	decrypted, err := a.wa.DecryptSecretEncryptedMessage(ctx, msg)
+	if err != nil {
+		a.emitWarning(
+			"secret_edit_decrypt_failed",
+			fmt.Sprintf("warning: failed to decrypt edit for message %s: %v", target, err),
+			map[string]any{"message_id": target, "error": err.Error()},
+		)
+		return false
+	}
+	if decrypted == nil {
+		return false
+	}
+
+	// Re-parse the plaintext so the edited body goes through the same
+	// extractors as any other message, rather than a second copy of that logic.
+	edited := wa.ParseLiveMessage(&events.Message{Info: msg.Info, Message: decrypted})
+	if !edited.Edited && strings.TrimSpace(edited.Text) == "" && edited.Media == nil {
+		return false
+	}
+
+	// Keep the envelope's identity out of the store: the edit belongs to the
+	// original row, which is what every reader already points at.
+	edited.ID = target
+	edited.Chat = pm.Chat
+	edited.SenderJID = pm.SenderJID
+	edited.PushName = pm.PushName
+	edited.Timestamp = pm.Timestamp
+	edited.Edited = true
+	*pm = edited
+	return true
 }
 
 // sendPresence sends a global presence update if the WhatsApp client is ready.

--- a/internal/app/sync_secret_edit_test.go
+++ b/internal/app/sync_secret_edit_test.go
@@ -1,0 +1,223 @@
+package app
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openclaw/wacli/internal/store"
+	waProto "go.mau.fi/whatsmeow/binary/proto"
+	"go.mau.fi/whatsmeow/proto/waCommon"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+// An incoming edit arrives as a SecretEncryptedMessage with
+// SecretEncType MESSAGE_EDIT and a TargetMessageKey pointing at the original,
+// not as a bare ProtocolMessage. Only POLL_ADD_OPTION is decrypted today, so
+// the edit is stored as a second empty row and the original keeps its
+// superseded text: the reader sees stale content that looks valid.
+func TestLiveSyncAppliesSecretEncryptedMessageEdit(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "34600000000", Server: types.DefaultUserServer}
+	originalID := "ORIGINAL-1"
+	sent := time.Date(2026, 9, 10, 12, 29, 56, 0, time.UTC)
+	var stored atomic.Int64
+
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            originalID,
+			Timestamp:     sent,
+		},
+		Message: &waProto.Message{Conversation: proto.String("Uno")},
+	}, &stored, func(string, string) {}, nil)
+
+	// What the server actually delivers for an edit.
+	f.decryptSecretFunc = func(_ *events.Message) (*waE2E.Message, error) {
+		return &waE2E.Message{
+			ProtocolMessage: &waE2E.ProtocolMessage{
+				Type: waE2E.ProtocolMessage_MESSAGE_EDIT.Enum(),
+				Key: &waCommon.MessageKey{
+					ID:        proto.String(originalID),
+					RemoteJID: proto.String(chat.String()),
+				},
+				EditedMessage: &waE2E.Message{Conversation: proto.String("Dos editado")},
+			},
+		}, nil
+	}
+
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            "EDIT-ENVELOPE-1",
+			Timestamp:     sent.Add(15 * time.Second),
+		},
+		Message: &waProto.Message{
+			SecretEncryptedMessage: &waE2E.SecretEncryptedMessage{
+				TargetMessageKey: &waCommon.MessageKey{
+					ID:        proto.String(originalID),
+					RemoteJID: proto.String(chat.String()),
+				},
+				SecretEncType: waE2E.SecretEncryptedMessage_MESSAGE_EDIT.Enum(),
+			},
+		},
+	}, &stored, func(string, string) {}, nil)
+
+	msgs, err := a.db.ListMessages(store.ListMessagesParams{ChatJID: chat.String(), Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+
+	var original *store.Message
+	for i := range msgs {
+		if msgs[i].MsgID == originalID {
+			original = &msgs[i]
+		}
+	}
+	if original == nil {
+		t.Fatalf("original row missing; got %d rows", len(msgs))
+	}
+
+	// The point of the bug: the reader gets the pre-edit text, which reads as
+	// valid, rather than a visible gap.
+	if original.Text != "Dos editado" {
+		t.Errorf("original text = %q, want %q (edit not applied)", original.Text, "Dos editado")
+	}
+	if !original.Edited {
+		t.Error("original.Edited = false, want true")
+	}
+
+	// And the envelope must not survive as a separate content-less row.
+	for _, m := range msgs {
+		if m.MsgID == "EDIT-ENVELOPE-1" {
+			t.Errorf("envelope stored as its own row (text=%q display=%q)", m.Text, m.DisplayText)
+		}
+	}
+}
+
+// helper: the envelope the server sends for an edit.
+func secretEditEvent(chat types.JID, envelopeID, targetID string, ts time.Time, t waE2E.SecretEncryptedMessage_SecretEncType) *events.Message {
+	return &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{Chat: chat, Sender: chat},
+			ID:            envelopeID,
+			Timestamp:     ts,
+		},
+		Message: &waProto.Message{
+			SecretEncryptedMessage: &waE2E.SecretEncryptedMessage{
+				TargetMessageKey: &waCommon.MessageKey{
+					ID:        proto.String(targetID),
+					RemoteJID: proto.String(chat.String()),
+				},
+				SecretEncType: t.Enum(),
+			},
+		},
+	}
+}
+
+// Messages can arrive out of order, so the edit may land before the message it
+// edits. The original must not then overwrite the newer body with its own.
+func TestSecretEncryptedEditSurvivesLateOriginal(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "34600000001", Server: types.DefaultUserServer}
+	originalID := "LATE-ORIGINAL"
+	sent := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	var stored atomic.Int64
+
+	f.decryptSecretFunc = func(_ *events.Message) (*waE2E.Message, error) {
+		return &waE2E.Message{
+			ProtocolMessage: &waE2E.ProtocolMessage{
+				Type:          waE2E.ProtocolMessage_MESSAGE_EDIT.Enum(),
+				Key:           &waCommon.MessageKey{ID: proto.String(originalID), RemoteJID: proto.String(chat.String())},
+				EditedMessage: &waE2E.Message{Conversation: proto.String("nuevo")},
+			},
+		}, nil
+	}
+	// Edit first.
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{},
+		secretEditEvent(chat, "ENV-LATE", originalID, sent.Add(time.Minute), waE2E.SecretEncryptedMessage_MESSAGE_EDIT),
+		&stored, func(string, string) {}, nil)
+	// Original after.
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{}, &events.Message{
+		Info:    types.MessageInfo{MessageSource: types.MessageSource{Chat: chat, Sender: chat}, ID: originalID, Timestamp: sent},
+		Message: &waProto.Message{Conversation: proto.String("viejo")},
+	}, &stored, func(string, string) {}, nil)
+
+	msgs, err := a.db.ListMessages(store.ListMessagesParams{ChatJID: chat.String(), Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	for _, m := range msgs {
+		if m.MsgID == originalID && m.Text != "nuevo" {
+			t.Fatalf("late original overwrote the edit: text = %q", m.Text)
+		}
+	}
+}
+
+// Only MESSAGE_EDIT envelopes belong to this path. Treating every
+// SecretEncryptedMessage as an edit would hijack poll and event traffic.
+func TestSecretEncryptedEditIgnoresOtherEncTypes(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "34600000002", Server: types.DefaultUserServer}
+	var stored atomic.Int64
+	called := false
+	f.decryptSecretFunc = func(_ *events.Message) (*waE2E.Message, error) {
+		called = true
+		return &waE2E.Message{Conversation: proto.String("no deberia usarse")}, nil
+	}
+
+	for _, enc := range []waE2E.SecretEncryptedMessage_SecretEncType{
+		waE2E.SecretEncryptedMessage_POLL_EDIT,
+		waE2E.SecretEncryptedMessage_EVENT_EDIT,
+		waE2E.SecretEncryptedMessage_MESSAGE_SCHEDULE,
+	} {
+		called = false
+		a.handleLiveSyncMessage(context.Background(), SyncOptions{},
+			secretEditEvent(chat, "ENV-"+enc.String(), "TARGET", time.Now().UTC(), enc),
+			&stored, func(string, string) {}, nil)
+		if called {
+			t.Errorf("%s was routed through the edit path", enc)
+		}
+	}
+}
+
+// A failed decrypt must warn and leave the message alone, not abort the sync or
+// invent content.
+func TestSecretEncryptedEditSurvivesDecryptFailure(t *testing.T) {
+	a := newTestApp(t)
+	f := newFakeWA()
+	a.wa = f
+
+	chat := types.JID{User: "34600000003", Server: types.DefaultUserServer}
+	var stored atomic.Int64
+	f.decryptSecretFunc = func(_ *events.Message) (*waE2E.Message, error) {
+		return nil, context.DeadlineExceeded
+	}
+
+	a.handleLiveSyncMessage(context.Background(), SyncOptions{},
+		secretEditEvent(chat, "ENV-FAIL", "TARGET-FAIL", time.Now().UTC(), waE2E.SecretEncryptedMessage_MESSAGE_EDIT),
+		&stored, func(string, string) {}, nil)
+
+	msgs, err := a.db.ListMessages(store.ListMessagesParams{ChatJID: chat.String(), Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	for _, m := range msgs {
+		if m.Text != "" {
+			t.Fatalf("invented content on decrypt failure: %q", m.Text)
+		}
+	}
+}


### PR DESCRIPTION
Fixes the behaviour reported in #343 and described in #245. The diagnosis in both points at the wrong layer, which is why the handling code looked correct while the bug persisted.

## What actually arrives

An incoming edit is **not** delivered as a bare `ProtocolMessage`. The server wraps it:

```
SecretEncryptedMessage {
    SecretEncType:    MESSAGE_EDIT
    TargetMessageKey: { ID: <id of the original> }
}
```

`DecryptSecretEncryptedMessage` already exists, but it is called from exactly one place, `handlePollAddOption`, for poll options. `SecretEncType` has six values and only `POLL_ADD_OPTION` was handled; `MESSAGE_EDIT` falls through to the unhandled path.

So the edit is stored as a **second content-less row** while the original keeps its superseded text, and `edited` stays `0`.

This explains why #245 looked fixed and was not: `extractProtocolMutation`'s `MESSAGE_EDIT` case is correct, and its test constructs that protobuf directly, so the handler passes. **The edit never reaches it.**

## Why this is worse than a visible gap

A missing message is noticeable. A superseded one reads as valid: the consumer gets text that was replaced, with nothing marking it stale and no flag to filter on.

Observed on a real account running `0.17.1` with the daemon connected. Incoming DM `Uno` at `12:29:56`, edited at `12:30:11`:

```
msg_id  A517346FD65C5DD14E7E79…   ts 12:29:56   edited 0   text 'Uno'    ← original, unchanged
msg_id  A5F0A6BFA8DC2377ADAEDF…   ts 12:30:11   edited 0   text NULL     ← the edit, empty
```

and in the log, from the diagnostic added in #344:

```
stored message A5F0A6BFA8DC2377ADAEDF… in <redacted>@s.whatsapp.net
without content: unhandled payload secretEncryptedMessage
```

The edited body is in no row of that chat. Same shape as the `0.15.2` reproduction in #343, two releases later.

## The change

Decrypts the envelope at the point where the encrypted-reaction path already hooks in, re-parses the plaintext through `ParseLiveMessage` so the edited body goes through the same extractors as any other message rather than a second copy of that logic, and applies it to the **original id** so the edit lands on the row every reader already points at.

59 lines in one file. No schema change, no new write path.

## Tests

Four cases, all red before:

| case | why it is there |
|---|---|
| edit applies to the original, sets `Edited`, envelope does not survive as its own row | the reported defect |
| edit arriving **before** the message it edits is not overwritten when the original lands | messages arrive out of order; without this the fix would reintroduce the stale text it removes |
| `POLL_EDIT`, `EVENT_EDIT`, `MESSAGE_SCHEDULE` untouched | the path must not hijack poll or event traffic |
| failed decrypt warns and leaves the message alone | must not invent content or abort the sync |

The existing poll suite stays green; it shares the same decrypt call and is the closest neighbour.

Red-before output on the first case, for reference:

```
stored message EDIT-ENVELOPE-1 ... without content: unhandled payload secretEncryptedMessage
    original text = "Uno", want "Dos editado" (edit not applied)
    original.Edited = false, want true
    envelope stored as its own row (text="" display="(message)")
```

## Gate

`gofmt -l` clean · `go vet ./...` · `go test ./...` · `go test -tags sqlite_fts5 ./...` · `go build -tags sqlite_fts5 ./cmd/wacli` · `git diff --check` — all pass.

## Note on scope

The other five `SecretEncType` values stay unhandled by design: this change covers `MESSAGE_EDIT` only, where content is demonstrably lost. Whether `POLL_EDIT` and `EVENT_EDIT` deserve the same treatment is a separate question and not assumed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
