### PR TITLE
chore: release 0.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.18.2 - 2026-09-11
 
 **Highlights:** mark chats read or unread while continuous sync owns the store.
 


### PR DESCRIPTION
Prepare patch 0.18.2 by dating the existing release notes 2026-09-11. Preserve the Highlights line, ordered notes, and all previously released sections.

The source version already reports 0.18.2. Documentation/release tests and independent review passed; the complete local gate and exact-head CI are required before landing and release dispatch. Publication uses the existing unified signing, notarization, independent rebuild, and Homebrew handoff workflow.
