### PR TITLE
refactor: use current Go idioms and deterministic sync test shutdown

### DIFF
--- a/cmd/wacli/auth.go
+++ b/cmd/wacli/auth.go
@@ -42,7 +42,7 @@ func newAuthCmd(flags *rootFlags) *cobra.Command {
 			}
 
 			if flags.asJSON {
-				return out.WriteJSON(os.Stdout, map[string]interface{}{
+				return out.WriteJSON(os.Stdout, map[string]any{
 					"authenticated":   true,
 					"messages_stored": res.MessagesStored,
 				})

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -29,7 +29,7 @@ type WAClient interface {
 	SetAutoReconnect(enabled bool) (previous bool, ok bool)
 	Connect(ctx context.Context, opts wa.ConnectOptions) error
 
-	AddEventHandler(handler func(interface{})) uint32
+	AddEventHandler(handler func(any)) uint32
 	RemoveEventHandler(id uint32)
 	ReconnectWithBackoff(ctx context.Context, minDelay, maxDelay time.Duration, opts wa.ConnectOptions) error
 
@@ -72,10 +72,10 @@ type WAClient interface {
 	RevokeMessage(ctx context.Context, chat types.JID, targetID types.MessageID) (types.MessageID, error)
 	DeleteMessageForMe(ctx context.Context, info types.MessageInfo, deleteMedia bool) error
 	EditMessage(ctx context.Context, chat types.JID, targetID types.MessageID, text string) (types.MessageID, error)
-	ArchiveChat(ctx context.Context, target types.JID, archive bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey, beforeApply func()) ([]interface{}, error)
-	PinChat(ctx context.Context, target types.JID, pin bool, beforeApply func()) ([]interface{}, error)
-	MuteChat(ctx context.Context, target types.JID, mute bool, duration time.Duration, beforeApply func()) ([]interface{}, error)
-	MarkChatAsRead(ctx context.Context, target types.JID, read bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey, beforeApply func()) ([]interface{}, error)
+	ArchiveChat(ctx context.Context, target types.JID, archive bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey, beforeApply func()) ([]any, error)
+	PinChat(ctx context.Context, target types.JID, pin bool, beforeApply func()) ([]any, error)
+	MuteChat(ctx context.Context, target types.JID, mute bool, duration time.Duration, beforeApply func()) ([]any, error)
+	MarkChatAsRead(ctx context.Context, target types.JID, read bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey, beforeApply func()) ([]any, error)
 	Upload(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error)
 	UploadNewsletter(ctx context.Context, data []byte, mediaType whatsmeow.MediaType) (whatsmeow.UploadResponse, error)
 	DownloadMediaToFile(ctx context.Context, directPath string, encFileHash, fileHash, mediaKey []byte, fileLength uint64, mediaType, mmsType string, targetPath string) (int64, error)
@@ -90,7 +90,7 @@ type WAClient interface {
 	DeleteHistorySyncMedia(ctx context.Context, notif *waE2E.HistorySyncNotification) error
 	RequestHistorySyncOnDemand(ctx context.Context, lastKnown types.MessageInfo, count int) (types.MessageID, error)
 	FetchAppState(ctx context.Context, name string, fullSync, onlyIfNotSynced bool) error
-	FetchAppStateEvents(ctx context.Context, name string, fullSync, onlyIfNotSynced bool) ([]interface{}, error)
+	FetchAppStateEvents(ctx context.Context, name string, fullSync, onlyIfNotSynced bool) ([]any, error)
 	RequestAppStateRecovery(ctx context.Context, name string) (types.MessageID, error)
 	Logout(ctx context.Context) error
 	LinkedJID() string

--- a/internal/app/backfill.go
+++ b/internal/app/backfill.go
@@ -104,7 +104,7 @@ func (a *App) BackfillHistory(ctx context.Context, opts BackfillOptions) (Backfi
 			return
 		}
 	}
-	handlerID := a.wa.AddEventHandler(func(evt interface{}) {
+	handlerID := a.wa.AddEventHandler(func(evt any) {
 		switch v := evt.(type) {
 		case *events.HistorySync:
 			handleOnDemand(v)

--- a/internal/app/backfill_test.go
+++ b/internal/app/backfill_test.go
@@ -54,7 +54,7 @@ func TestBackfillHistoryRetriesUnansweredAnchor(t *testing.T) {
 				t.Fatalf("oldest = %+v, err = %v", oldest, err)
 			}
 			warnings := 0
-			for _, line := range bytes.Split(bytes.TrimSpace(eventLog.Bytes()), []byte("\n")) {
+			for line := range bytes.SplitSeq(bytes.TrimSpace(eventLog.Bytes()), []byte("\n")) {
 				var event struct {
 					Data map[string]any `json:"data"`
 				}
@@ -291,7 +291,7 @@ func TestBackfillHistoryDownloadsManualOnDemandNotification(t *testing.T) {
 
 	syncType := waE2E.HistorySyncType_ON_DEMAND
 	notif := &waE2E.HistorySyncNotification{SyncType: &syncType}
-	f.onDemandEvent = func(lastKnown types.MessageInfo, count int) interface{} {
+	f.onDemandEvent = func(lastKnown types.MessageInfo, count int) any {
 		return &events.Message{
 			Message: &waProto.Message{
 				ProtocolMessage: &waProto.ProtocolMessage{

--- a/internal/app/chat_state.go
+++ b/internal/app/chat_state.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -32,7 +33,7 @@ func (a *App) AddChatStatePersistenceHandler(ctx context.Context) (func(), error
 		return nil, err
 	}
 	waClient := a.WA()
-	handlerID := waClient.AddEventHandler(func(evt interface{}) {
+	handlerID := waClient.AddEventHandler(func(evt any) {
 		switch evt.(type) {
 		case *events.AppState, *events.Star, *events.DeleteForMe,
 			*events.Archive, *events.Pin, *events.Mute, *events.MarkChatAsRead:
@@ -246,14 +247,14 @@ func (a *App) recoverMismatchingAppState(ctx context.Context, collection appstat
 	return a.clearCompletedAppStateRecovery(collection, markerGeneration)
 }
 
-func (a *App) waitForPrimaryAppStateRecovery(ctx context.Context, collection appstate.WAPatchName) ([]interface{}, error) {
-	completed := make(chan []interface{}, 1)
+func (a *App) waitForPrimaryAppStateRecovery(ctx context.Context, collection appstate.WAPatchName) ([]any, error) {
+	completed := make(chan []any, 1)
 	var mu sync.Mutex
-	var captured []interface{}
+	var captured []any
 	finished := false
 	// whatsmeow dispatches recovery mutations synchronously and emits this
 	// collection's AppStateSyncComplete last, so the sentinel closes the drain.
-	handlerID := a.wa.AddEventHandler(func(evt interface{}) {
+	handlerID := a.wa.AddEventHandler(func(evt any) {
 		mu.Lock()
 		defer mu.Unlock()
 		if finished {
@@ -262,15 +263,12 @@ func (a *App) waitForPrimaryAppStateRecovery(ctx context.Context, collection app
 		if syncComplete, ok := evt.(*events.AppStateSyncComplete); ok {
 			if syncComplete != nil && syncComplete.Recovery && syncComplete.Name == collection {
 				finished = true
-				completed <- append([]interface{}(nil), captured...)
+				completed <- append([]any(nil), captured...)
 			}
 			return
 		}
-		for _, eventCollection := range appStateCollectionsForEvent(evt) {
-			if eventCollection == collection {
-				captured = append(captured, evt)
-				break
-			}
+		if slices.Contains(appStateCollectionsForEvent(evt), collection) {
+			captured = append(captured, evt)
 		}
 	})
 	defer a.wa.RemoveEventHandler(handlerID)
@@ -294,7 +292,7 @@ func (a *App) waitForPrimaryAppStateRecovery(ctx context.Context, collection app
 
 func (a *App) fetchAndPersistAppState(ctx context.Context, collection appstate.WAPatchName, fullSync bool, tracker *appStatePersistenceTracker) (fetchErr, persistenceErr error) {
 	ticket := a.appStatePersist.reserve()
-	var eventsToPersist []interface{}
+	var eventsToPersist []any
 	func() {
 		releaseFetch := a.beginManualAppStateFetch(collection)
 		defer releaseFetch()
@@ -376,7 +374,7 @@ func (a *App) beginLocalAppStateWrite(collection appstate.WAPatchName) (pendingL
 	return pendingLocalAppStateWrite{collection: collection, generation: generation}, nil
 }
 
-func (a *App) failLocalAppStateWrite(ctx context.Context, pending *pendingLocalAppStateWrite, postSendEvents []interface{}) error {
+func (a *App) failLocalAppStateWrite(ctx context.Context, pending *pendingLocalAppStateWrite, postSendEvents []any) error {
 	if !pending.reserved {
 		return nil
 	}
@@ -392,7 +390,7 @@ func (a *App) failLocalAppStateWrite(ctx context.Context, pending *pendingLocalA
 	return <-result
 }
 
-func (a *App) completeLocalAppStateWrite(ctx context.Context, pending *pendingLocalAppStateWrite, postSendEvents []interface{}, persist func() error) error {
+func (a *App) completeLocalAppStateWrite(ctx context.Context, pending *pendingLocalAppStateWrite, postSendEvents []any, persist func() error) error {
 	result := make(chan error, 1)
 	persistCtx := context.WithoutCancel(ctx)
 	frontier := a.appStatePersist.complete(pending.ticket, func() {
@@ -413,7 +411,7 @@ func (a *App) completeLocalAppStateWrite(ctx context.Context, pending *pendingLo
 	return <-result
 }
 
-func (a *App) persistFetchedAppStateEvents(ctx context.Context, eventsToPersist []interface{}, tracker *appStatePersistenceTracker) error {
+func (a *App) persistFetchedAppStateEvents(ctx context.Context, eventsToPersist []any, tracker *appStatePersistenceTracker) error {
 	tracker.begin()
 	for _, evt := range eventsToPersist {
 		a.handleAppStatePersistenceEvent(ctx, evt, tracker)
@@ -451,7 +449,7 @@ func messageKeyFromStore(info store.MessageInfo) *waCommon.MessageKey {
 	return key
 }
 
-func (a *App) handleChatStateEvent(ctx context.Context, evt interface{}) error {
+func (a *App) handleChatStateEvent(ctx context.Context, evt any) error {
 	switch v := evt.(type) {
 	case *events.Archive:
 		if v == nil || v.JID.IsEmpty() || v.Action == nil {

--- a/internal/app/fake_wa_test.go
+++ b/internal/app/fake_wa_test.go
@@ -32,9 +32,9 @@ type fakeWA struct {
 	linkedLID     string
 
 	nextHandlerID uint32
-	handlers      map[uint32]func(interface{})
+	handlers      map[uint32]func(any)
 
-	connectEvents  []interface{}
+	connectEvents  []any
 	connectErrs    []error
 	connectCalls   int
 	connectDelay   time.Duration
@@ -42,7 +42,7 @@ type fakeWA struct {
 	downloadDelay  time.Duration
 	downloadErr    error
 
-	onMediaRetry       func(info *types.MessageInfo, mediaKey []byte) interface{}
+	onMediaRetry       func(info *types.MessageInfo, mediaKey []byte) any
 	mediaRetryReceipts []string
 
 	contacts map[types.JID]types.ContactInfo
@@ -60,7 +60,7 @@ type fakeWA struct {
 	decryptPollVoteFunc         func(evt *events.Message) (*waE2E.PollVoteMessage, error)
 	decryptSecretFunc           func(evt *events.Message) (*waE2E.Message, error)
 	onDemandHistory             func(lastKnown types.MessageInfo, count int) *events.HistorySync
-	onDemandEvent               func(lastKnown types.MessageInfo, count int) interface{}
+	onDemandEvent               func(lastKnown types.MessageInfo, count int) any
 	onDemandErr                 error
 	downloadHistory             func(notif *waE2E.HistorySyncNotification) (*waHistorySync.HistorySync, error)
 	deleteHistoryCalls          []*waE2E.HistorySyncNotification
@@ -68,8 +68,8 @@ type fakeWA struct {
 	onAppStateRecovery          func(name string)
 	appStateFetchErr            error
 	appStateFetchErrs           []error
-	appStateFetchEvent          func(name string, fullSync, onlyIfNotSynced bool) interface{}
-	archiveEvent                func() interface{}
+	appStateFetchEvent          func(name string, fullSync, onlyIfNotSynced bool) any
+	archiveEvent                func() any
 	archiveErr                  error
 	archiveCalls                []fakeArchiveCall
 	pinCalls                    []fakePinCall
@@ -132,7 +132,7 @@ func newFakeWA() *fakeWA {
 	return &fakeWA{
 		authed:        true,
 		autoReconnect: true,
-		handlers:      map[uint32]func(interface{}){},
+		handlers:      map[uint32]func(any){},
 		contacts:      map[types.JID]types.ContactInfo{},
 		groups:        map[types.JID]*types.GroupInfo{},
 		news:          map[types.JID]*types.NewsletterMetadata{},
@@ -141,9 +141,9 @@ func newFakeWA() *fakeWA {
 	}
 }
 
-func (f *fakeWA) emit(evt interface{}) {
+func (f *fakeWA) emit(evt any) {
 	f.mu.Lock()
-	handlers := make([]func(interface{}), 0, len(f.handlers))
+	handlers := make([]func(any), 0, len(f.handlers))
 	for _, h := range f.handlers {
 		handlers = append(handlers, h)
 	}
@@ -193,7 +193,7 @@ func (f *fakeWA) Connect(ctx context.Context, opts wa.ConnectOptions) error {
 		f.connectErrs = f.connectErrs[1:]
 	}
 	f.connected = true
-	eventsToEmit := append([]interface{}{}, f.connectEvents...)
+	eventsToEmit := append([]any{}, f.connectEvents...)
 	f.mu.Unlock()
 
 	if !authed && !opts.AllowQR {
@@ -225,7 +225,7 @@ func (f *fakeWA) Connect(ctx context.Context, opts wa.ConnectOptions) error {
 	return nil
 }
 
-func (f *fakeWA) AddEventHandler(handler func(interface{})) uint32 {
+func (f *fakeWA) AddEventHandler(handler func(any)) uint32 {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	id := f.nextHandlerID
@@ -738,7 +738,7 @@ func (f *fakeWA) DeleteMessageForMe(ctx context.Context, info types.MessageInfo,
 	return nil
 }
 
-func (f *fakeWA) ArchiveChat(ctx context.Context, target types.JID, archive bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey, beforeApply func()) ([]interface{}, error) {
+func (f *fakeWA) ArchiveChat(ctx context.Context, target types.JID, archive bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey, beforeApply func()) ([]any, error) {
 	f.mu.Lock()
 	f.archiveCalls = append(f.archiveCalls, fakeArchiveCall{target: target, archive: archive, lastMsgTS: lastMsgTS, lastMsgKey: lastMsgKey})
 	eventCB := f.archiveEvent
@@ -746,13 +746,13 @@ func (f *fakeWA) ArchiveChat(ctx context.Context, target types.JID, archive bool
 	beforeApply()
 	if eventCB != nil {
 		if evt := eventCB(); evt != nil {
-			return []interface{}{evt}, f.archiveErr
+			return []any{evt}, f.archiveErr
 		}
 	}
 	return nil, f.archiveErr
 }
 
-func (f *fakeWA) PinChat(ctx context.Context, target types.JID, pin bool, beforeApply func()) ([]interface{}, error) {
+func (f *fakeWA) PinChat(ctx context.Context, target types.JID, pin bool, beforeApply func()) ([]any, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.pinCalls = append(f.pinCalls, fakePinCall{target: target, pin: pin})
@@ -760,7 +760,7 @@ func (f *fakeWA) PinChat(ctx context.Context, target types.JID, pin bool, before
 	return nil, nil
 }
 
-func (f *fakeWA) MuteChat(ctx context.Context, target types.JID, mute bool, duration time.Duration, beforeApply func()) ([]interface{}, error) {
+func (f *fakeWA) MuteChat(ctx context.Context, target types.JID, mute bool, duration time.Duration, beforeApply func()) ([]any, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.muteCalls = append(f.muteCalls, fakeMuteCall{target: target, mute: mute, duration: duration})
@@ -768,7 +768,7 @@ func (f *fakeWA) MuteChat(ctx context.Context, target types.JID, mute bool, dura
 	return nil, nil
 }
 
-func (f *fakeWA) MarkChatAsRead(ctx context.Context, target types.JID, read bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey, beforeApply func()) ([]interface{}, error) {
+func (f *fakeWA) MarkChatAsRead(ctx context.Context, target types.JID, read bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey, beforeApply func()) ([]any, error) {
 	f.mu.Lock()
 	f.markReadCalls = append(f.markReadCalls, fakeMarkReadCall{target: target, read: read, lastMsgTS: lastMsgTS, lastMsgKey: lastMsgKey})
 	hook := f.markReadBeforeApply
@@ -805,7 +805,7 @@ func (f *fakeWA) FetchAppState(ctx context.Context, name string, fullSync, onlyI
 	return nil
 }
 
-func (f *fakeWA) FetchAppStateEvents(ctx context.Context, name string, fullSync, onlyIfNotSynced bool) ([]interface{}, error) {
+func (f *fakeWA) FetchAppStateEvents(ctx context.Context, name string, fullSync, onlyIfNotSynced bool) ([]any, error) {
 	f.mu.Lock()
 	f.appStateFetches = append(f.appStateFetches, fakeAppStateFetch{
 		name:            name,
@@ -832,7 +832,7 @@ func (f *fakeWA) FetchAppStateEvents(ctx context.Context, name string, fullSync,
 	if evt == nil {
 		return nil, nil
 	}
-	return []interface{}{evt}, nil
+	return []any{evt}, nil
 }
 
 func (f *fakeWA) Logout(ctx context.Context) error {

--- a/internal/app/heartbeat_test.go
+++ b/internal/app/heartbeat_test.go
@@ -300,7 +300,7 @@ func TestSyncFollowEmitsStaleEvent(t *testing.T) {
 		Data  map[string]any `json:"data"`
 	}
 	var found bool
-	for _, line := range bytes.Split(bytes.TrimSpace(eventsOut.Bytes()), []byte("\n")) {
+	for line := range bytes.SplitSeq(bytes.TrimSpace(eventsOut.Bytes()), []byte("\n")) {
 		if len(bytes.TrimSpace(line)) == 0 {
 			continue
 		}

--- a/internal/app/media_retry.go
+++ b/internal/app/media_retry.go
@@ -111,7 +111,7 @@ func (a *App) RetryMedia(ctx context.Context, opts RetryMediaOptions) (MediaRetr
 	infos := make(map[mediaRetryKey]store.MediaDownloadInfo, len(pending))
 	notifs := make(map[mediaRetryKey]retryNotif, len(pending))
 
-	handlerID := a.wa.AddEventHandler(func(evt interface{}) {
+	handlerID := a.wa.AddEventHandler(func(evt any) {
 		mr, ok := evt.(*events.MediaRetry)
 		if !ok {
 			return
@@ -266,10 +266,7 @@ func (a *App) RetryMedia(ctx context.Context, opts RetryMediaOptions) (MediaRetr
 		if ctx.Err() != nil {
 			break
 		}
-		end := start + opts.BatchSize
-		if end > len(orderedKeys) {
-			end = len(orderedKeys)
-		}
+		end := min(start+opts.BatchSize, len(orderedKeys))
 		batch := orderedKeys[start:end]
 
 		for _, key := range batch {

--- a/internal/app/media_retry_test.go
+++ b/internal/app/media_retry_test.go
@@ -13,7 +13,7 @@ import (
 	"go.mau.fi/whatsmeow/types/events"
 )
 
-func notOnPhoneHook(info *types.MessageInfo, _ []byte) interface{} {
+func notOnPhoneHook(info *types.MessageInfo, _ []byte) any {
 	return &events.MediaRetry{MessageID: types.MessageID(info.ID), ChatID: info.Chat, Error: &events.MediaRetryError{Code: 2}}
 }
 
@@ -243,7 +243,7 @@ func TestRetryMediaMatchesLIDNotificationToCanonicalChat(t *testing.T) {
 	pn := types.NewJID("123", types.DefaultUserServer)
 	lid := types.NewJID("999", types.HiddenUserServer)
 	f.lids[lid] = pn
-	f.onMediaRetry = func(info *types.MessageInfo, _ []byte) interface{} {
+	f.onMediaRetry = func(info *types.MessageInfo, _ []byte) any {
 		return &events.MediaRetry{MessageID: types.MessageID(info.ID), ChatID: lid, Error: &events.MediaRetryError{Code: 2}}
 	}
 
@@ -267,7 +267,7 @@ func TestRetryMediaTreatsBroadcastListsAsGroupLike(t *testing.T) {
 	a.wa = f
 	f.downloadErr = whatsmeow.ErrMediaDownloadFailedWith403
 	var receiptSource types.MessageSource
-	f.onMediaRetry = func(info *types.MessageInfo, _ []byte) interface{} {
+	f.onMediaRetry = func(info *types.MessageInfo, _ []byte) any {
 		receiptSource = info.MessageSource
 		return &events.MediaRetry{MessageID: types.MessageID(info.ID), ChatID: info.Chat, Error: &events.MediaRetryError{Code: 2}}
 	}
@@ -302,7 +302,7 @@ func TestRetryMediaUsesOwnSenderForOutgoingGroupMedia(t *testing.T) {
 	a.wa = f
 	f.downloadErr = whatsmeow.ErrMediaDownloadFailedWith403
 	var receiptSender types.JID
-	f.onMediaRetry = func(info *types.MessageInfo, _ []byte) interface{} {
+	f.onMediaRetry = func(info *types.MessageInfo, _ []byte) any {
 		receiptSender = info.Sender
 		return &events.MediaRetry{MessageID: types.MessageID(info.ID), ChatID: info.Chat, Error: &events.MediaRetryError{Code: 2}}
 	}

--- a/internal/app/sync_events.go
+++ b/internal/app/sync_events.go
@@ -62,7 +62,7 @@ func (a *App) addSyncEventHandler(ctx context.Context, opts SyncOptions, message
 	if !opts.WebhookEvents.Enabled(SyncWebhookEventMessage) {
 		enqueueWebhookMessage = func(wa.ParsedMessage) {}
 	}
-	return a.wa.AddEventHandler(func(evt interface{}) {
+	return a.wa.AddEventHandler(func(evt any) {
 		if mediaQ != nil {
 			if !mediaQ.beginProducer() {
 				return
@@ -215,7 +215,7 @@ func (a *App) handleKeepAliveTimeout(opts SyncOptions, evt *events.KeepAliveTime
 	}
 }
 
-func syncActivityEvent(evt interface{}) bool {
+func syncActivityEvent(evt any) bool {
 	switch evt.(type) {
 	case nil,
 		*events.KeepAliveTimeout,
@@ -237,7 +237,7 @@ func syncActivityEvent(evt interface{}) bool {
 	}
 }
 
-func (a *App) handleAppStatePersistenceEvent(ctx context.Context, evt interface{}, tracker *appStatePersistenceTracker) {
+func (a *App) handleAppStatePersistenceEvent(ctx context.Context, evt any, tracker *appStatePersistenceTracker) {
 	if tracker != nil {
 		a.persistAppStateEvent(ctx, evt, tracker)
 		return
@@ -290,7 +290,7 @@ type appStateRecoveryMarker struct {
 	generation int64
 }
 
-func (a *App) markLiveAppStateRecovery(evt interface{}) ([]appStateRecoveryMarker, error) {
+func (a *App) markLiveAppStateRecovery(evt any) ([]appStateRecoveryMarker, error) {
 	collections := appStateCollectionsForEvent(evt)
 	names := make([]string, len(collections))
 	for i, collection := range collections {
@@ -319,7 +319,7 @@ func (a *App) clearLiveAppStateRecovery(markers []appStateRecoveryMarker) {
 	}
 }
 
-func (a *App) persistAppStateEvent(ctx context.Context, evt interface{}, tracker *appStatePersistenceTracker) error {
+func (a *App) persistAppStateEvent(ctx context.Context, evt any, tracker *appStatePersistenceTracker) error {
 	var err error
 	switch v := evt.(type) {
 	case *events.AppState:
@@ -337,7 +337,7 @@ func (a *App) persistAppStateEvent(ctx context.Context, evt interface{}, tracker
 	return err
 }
 
-func appStateCollectionsForEvent(evt interface{}) []appstate.WAPatchName {
+func appStateCollectionsForEvent(evt any) []appstate.WAPatchName {
 	switch v := evt.(type) {
 	case *events.Archive, *events.Pin, *events.MarkChatAsRead:
 		return []appstate.WAPatchName{appstate.WAPatchRegularLow}
@@ -406,7 +406,7 @@ func (a *App) handleDeleteForMeEvent(ctx context.Context, evt *events.DeleteForM
 	return nil
 }
 
-func (a *App) handleLiveCallEvent(ctx context.Context, evt interface{}) error {
+func (a *App) handleLiveCallEvent(ctx context.Context, evt any) error {
 	self := a.linkedLiveCallIdentity()
 	var alternateSelf []types.JID
 	if _, ok := evt.(*events.AppState); ok {

--- a/internal/app/sync_events_output_test.go
+++ b/internal/app/sync_events_output_test.go
@@ -24,7 +24,7 @@ func TestSyncEventsOutputStaysNDJSONDuringProgress(t *testing.T) {
 	for i := range ids {
 		ids[i] = "m" + string(rune('a'+i))
 	}
-	f.connectEvents = []interface{}{historySyncWithTextMessages(chat, base, ids...)}
+	f.connectEvents = []any{historySyncWithTextMessages(chat, base, ids...)}
 
 	raw := captureStderr(t, func() {
 		a.opts.Events = out.NewEventWriter(os.Stderr, true)
@@ -46,7 +46,7 @@ func TestSyncEventsOutputStaysNDJSONDuringProgress(t *testing.T) {
 	}
 
 	var sawProgress bool
-	for _, line := range strings.Split(strings.TrimSpace(raw), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(raw), "\n") {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
@@ -82,7 +82,7 @@ func TestSyncTTYProgressUsesSingleStatusLine(t *testing.T) {
 	for i := range ids {
 		ids[i] = "m" + string(rune('a'+i))
 	}
-	f.connectEvents = []interface{}{historySyncWithTextMessages(chat, base, ids...)}
+	f.connectEvents = []any{historySyncWithTextMessages(chat, base, ids...)}
 
 	raw := captureStderr(t, func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/internal/app/sync_limits_test.go
+++ b/internal/app/sync_limits_test.go
@@ -25,7 +25,7 @@ func TestSyncStopsAtMaxMessages(t *testing.T) {
 
 	chat := types.JID{User: "123", Server: types.DefaultUserServer}
 	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	f.connectEvents = []interface{}{historySyncWithTextMessages(chat, base, "m1", "m2", "m3")}
+	f.connectEvents = []any{historySyncWithTextMessages(chat, base, "m1", "m2", "m3")}
 
 	res, err := a.Sync(context.Background(), SyncOptions{
 		Mode:        SyncModeFollow,
@@ -50,7 +50,7 @@ func TestSyncFlushesHistoryPollsAtMaxMessages(t *testing.T) {
 
 	chat := types.JID{User: "123", Server: types.DefaultUserServer}
 	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	f.connectEvents = []interface{}{historySyncWithPollAndText(chat, base, "poll-limit", "after-limit")}
+	f.connectEvents = []any{historySyncWithPollAndText(chat, base, "poll-limit", "after-limit")}
 
 	res, err := a.Sync(context.Background(), SyncOptions{
 		Mode:        SyncModeFollow,
@@ -95,7 +95,7 @@ func TestSyncFlushesFinalHistoryPollVoteAtMaxMessages(t *testing.T) {
 	f.decryptPollVoteFunc = func(_ *events.Message) (*waE2E.PollVoteMessage, error) {
 		return &waE2E.PollVoteMessage{SelectedOptions: whatsmeow.HashPollOptions([]string{"Yes"})}, nil
 	}
-	f.connectEvents = []interface{}{historySyncWithPollVote(chat, voter, base, pollMsgID, "vote-final-limit")}
+	f.connectEvents = []any{historySyncWithPollVote(chat, voter, base, pollMsgID, "vote-final-limit")}
 
 	res, err := a.Sync(context.Background(), SyncOptions{
 		Mode:        SyncModeFollow,
@@ -140,7 +140,7 @@ func TestSyncFlushesFinalLivePollVoteAtMaxMessages(t *testing.T) {
 	f.decryptPollVoteFunc = func(_ *events.Message) (*waE2E.PollVoteMessage, error) {
 		return &waE2E.PollVoteMessage{SelectedOptions: whatsmeow.HashPollOptions([]string{"Yes"})}, nil
 	}
-	f.connectEvents = []interface{}{livePollVote(chat, voter, base, pollMsgID, "vote-live-limit")}
+	f.connectEvents = []any{livePollVote(chat, voter, base, pollMsgID, "vote-live-limit")}
 
 	res, err := a.Sync(context.Background(), SyncOptions{
 		Mode:        SyncModeFollow,

--- a/internal/app/sync_logout_test.go
+++ b/internal/app/sync_logout_test.go
@@ -17,7 +17,7 @@ import (
 // with the given name, failing the test if none is present.
 func findEventByName(t *testing.T, raw, name string) map[string]any {
 	t.Helper()
-	for _, line := range strings.Split(strings.TrimSpace(raw), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(raw), "\n") {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
@@ -202,7 +202,7 @@ func TestRunSyncFollowLoggedOutWinsOverPendingReconnect(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			for i := 0; i < 50; i++ {
+			for i := range 50 {
 				a := newTestApp(t)
 				f := newFakeWA()
 				a.wa = f
@@ -320,7 +320,7 @@ func TestRunSyncUntilIdleStopsOnLoggedOut(t *testing.T) {
 // Same pairing race in the idle loop: with disconnected and loggedOut both
 // queued, the loop must stop without reconnecting.
 func TestRunSyncUntilIdleLoggedOutWinsOverDisconnected(t *testing.T) {
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		a := newTestApp(t)
 		f := newFakeWA()
 		a.wa = f

--- a/internal/app/sync_panic_test.go
+++ b/internal/app/sync_panic_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"go.mau.fi/whatsmeow/types/events"
 )
@@ -22,6 +21,8 @@ func captureStderr(t *testing.T, fn func()) string {
 	if err != nil {
 		t.Fatalf("os.Pipe: %v", err)
 	}
+	defer r.Close()
+	defer w.Close()
 	os.Stderr = w
 	defer func() { os.Stderr = orig }()
 
@@ -52,15 +53,19 @@ func TestSyncEventHandlerPanicHasStackAndCounter(t *testing.T) {
 	// Sync is running forces the handler to recover twice, so we can check
 	// the counter increments.
 	var nilMsg *events.Message
-	f.connectEvents = []interface{}{nilMsg, nilMsg}
+	f.connectEvents = []any{nilMsg, nilMsg}
 
 	out := captureStderr(t, func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		go func() {
-			time.Sleep(100 * time.Millisecond)
-			cancel()
-		}()
-		if _, err := a.Sync(ctx, SyncOptions{Mode: SyncModeFollow, AllowQR: false}); err != nil {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		if _, err := a.Sync(ctx, SyncOptions{
+			Mode:    SyncModeFollow,
+			AllowQR: false,
+			AfterConnect: func(context.Context) error {
+				cancel()
+				return nil
+			},
+		}); err != nil {
 			t.Fatalf("Sync: %v", err)
 		}
 	})

--- a/internal/app/sync_polls.go
+++ b/internal/app/sync_polls.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -198,10 +199,8 @@ func (a *App) handlePollAddOption(ctx context.Context, pm wa.ParsedMessage, evt 
 			return
 		}
 	}
-	for _, existing := range poll.Options {
-		if existing == option {
-			return
-		}
+	if slices.Contains(poll.Options, option) {
+		return
 	}
 	poll.Options = append(poll.Options, option)
 	if err := a.db.UpsertPoll(poll); err != nil {

--- a/internal/app/sync_presence_test.go
+++ b/internal/app/sync_presence_test.go
@@ -54,7 +54,7 @@ func TestSyncSendsAvailablePresenceOnPushNameSetting(t *testing.T) {
 	a.wa = f
 
 	// Fake the server sending a pushname update after the initial connect.
-	f.connectEvents = []interface{}{&events.PushNameSetting{}}
+	f.connectEvents = []any{&events.PushNameSetting{}}
 
 	raw := captureStderr(t, func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -84,10 +84,10 @@ func TestSyncSendsAvailablePresenceOnPushNameSetting(t *testing.T) {
 func TestSyncQuietPresenceModeSkipsAvailablePresence(t *testing.T) {
 	tests := []struct {
 		name          string
-		connectEvents []interface{}
+		connectEvents []any
 	}{
 		{name: "connected only"},
-		{name: "push name", connectEvents: []interface{}{&events.PushNameSetting{}}},
+		{name: "push name", connectEvents: []any{&events.PushNameSetting{}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -760,7 +760,7 @@ func TestSyncFetchesChatAppStateDeltasAfterConnect(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertMessage: %v", err)
 	}
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		if onlyIfNotSynced {
 			return nil
 		}
@@ -908,7 +908,7 @@ func TestChatStatePersistenceHandlerCoversOtherCollectionDuringWrite(t *testing.
 			t.Fatalf("UpsertChat: %v", err)
 		}
 	}
-	f.connectEvents = []interface{}{&events.Mute{
+	f.connectEvents = []any{&events.Mute{
 		JID:    remoteMute,
 		Action: &waSyncAction.MuteAction{Muted: proto.Bool(true), MuteEndTimestamp: proto.Int64(-1)},
 	}}
@@ -1169,7 +1169,7 @@ func TestArchiveChatPersistsAppStateDeltasFetchedBeforeWrite(t *testing.T) {
 			t.Fatalf("UpsertChat: %v", err)
 		}
 	}
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		return &events.Archive{
 			JID:    pending,
 			Action: &waSyncAction.ArchiveChatAction{Archived: proto.Bool(true)},
@@ -1201,7 +1201,7 @@ func TestArchiveChatMarksRecoveryBeforeCursorAdvancingFetch(t *testing.T) {
 	a.wa = f
 
 	markerSeen := false
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		var err error
 		markerSeen, err = a.db.AppStateRecoveryRequired(name)
 		if err != nil {
@@ -1230,7 +1230,7 @@ func TestArchiveChatDoesNotAttributeConcurrentCollectionEvents(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()
 	a.wa = f
-	handlerID := f.AddEventHandler(func(evt interface{}) {
+	handlerID := f.AddEventHandler(func(evt any) {
 		a.handleAppStatePersistenceEvent(context.Background(), evt, nil)
 	})
 	defer f.RemoveEventHandler(handlerID)
@@ -1259,7 +1259,7 @@ func TestArchiveChatDoesNotAttributeConcurrentCollectionEvents(t *testing.T) {
 		t.Fatalf("create failure trigger: %v", err)
 	}
 	unrelatedMarkerSeen := false
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		f.emit(&events.Mute{
 			JID:    remoteMute,
 			Action: &waSyncAction.MuteAction{Muted: proto.Bool(true)},
@@ -1308,7 +1308,7 @@ func TestArchiveChatDoesNotClearConcurrentSameCollectionFailure(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()
 	a.wa = f
-	handlerID := f.AddEventHandler(func(evt interface{}) {
+	handlerID := f.AddEventHandler(func(evt any) {
 		a.handleAppStatePersistenceEvent(context.Background(), evt, nil)
 	})
 	defer f.RemoveEventHandler(handlerID)
@@ -1336,7 +1336,7 @@ func TestArchiveChatDoesNotClearConcurrentSameCollectionFailure(t *testing.T) {
 	`); err != nil {
 		t.Fatalf("create failure trigger: %v", err)
 	}
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		f.emit(&events.Archive{
 			JID:    remoteArchive,
 			Action: &waSyncAction.ArchiveChatAction{Archived: proto.Bool(true)},
@@ -1376,11 +1376,11 @@ func TestArchiveChatOrdersFetchedEventsBeforeNewerLiveEvents(t *testing.T) {
 			t.Fatalf("UpsertChat: %v", err)
 		}
 	}
-	handlerID := f.AddEventHandler(func(evt interface{}) {
+	handlerID := f.AddEventHandler(func(evt any) {
 		a.handleAppStatePersistenceEvent(context.Background(), evt, nil)
 	})
 	defer f.RemoveEventHandler(handlerID)
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		f.emit(&events.Archive{
 			JID:       remoteArchive,
 			Timestamp: when.Add(2 * time.Minute),
@@ -1409,7 +1409,7 @@ func TestArchiveChatPersistsRecoveredMarkUnread(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()
 	a.wa = f
-	handlerID := f.AddEventHandler(func(evt interface{}) {
+	handlerID := f.AddEventHandler(func(evt any) {
 		switch v := evt.(type) {
 		case *events.MarkChatAsRead:
 			a.handleAppStatePersistenceEvent(context.Background(), v, nil)
@@ -1427,7 +1427,7 @@ func TestArchiveChatPersistsRecoveredMarkUnread(t *testing.T) {
 			t.Fatalf("UpsertChat: %v", err)
 		}
 	}
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		return &events.MarkChatAsRead{
 			JID:       remote,
 			Timestamp: when,
@@ -1451,7 +1451,7 @@ func TestMarkChatReadOrdersPreSendReceiptBeforeLocalMutation(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()
 	a.wa = f
-	handlerID := f.AddEventHandler(func(evt interface{}) {
+	handlerID := f.AddEventHandler(func(evt any) {
 		if receipt, ok := evt.(*events.Receipt); ok {
 			a.handleReceiptPersistenceEvent(context.Background(), receipt)
 		}
@@ -1608,7 +1608,7 @@ func TestArchiveChatOrdersPostSendEventsBeforeNewerLiveEventDuringApply(t *testi
 	a := newTestApp(t)
 	f := newFakeWA()
 	a.wa = f
-	handlerID := f.AddEventHandler(func(evt interface{}) {
+	handlerID := f.AddEventHandler(func(evt any) {
 		a.handleAppStatePersistenceEvent(context.Background(), evt, nil)
 	})
 	defer f.RemoveEventHandler(handlerID)
@@ -1618,7 +1618,7 @@ func TestArchiveChatOrdersPostSendEventsBeforeNewerLiveEventDuringApply(t *testi
 	if err := a.db.UpsertChat(target.String(), "dm", "Alice", when); err != nil {
 		t.Fatalf("UpsertChat: %v", err)
 	}
-	f.archiveEvent = func() interface{} {
+	f.archiveEvent = func() any {
 		f.emit(&events.Archive{
 			JID:       target,
 			Timestamp: nowUTC().Add(time.Minute),
@@ -1647,7 +1647,7 @@ func TestArchiveChatReplaysEventDispatchedAfterWriteCompletion(t *testing.T) {
 	a := newTestApp(t)
 	f := newFakeWA()
 	a.wa = f
-	handlerID := f.AddEventHandler(func(evt interface{}) {
+	handlerID := f.AddEventHandler(func(evt any) {
 		a.handleAppStatePersistenceEvent(context.Background(), evt, nil)
 	})
 	defer f.RemoveEventHandler(handlerID)
@@ -1657,7 +1657,7 @@ func TestArchiveChatReplaysEventDispatchedAfterWriteCompletion(t *testing.T) {
 	if err := a.db.UpsertChat(target.String(), "dm", "Alice", when); err != nil {
 		t.Fatalf("UpsertChat: %v", err)
 	}
-	f.archiveEvent = func() interface{} {
+	f.archiveEvent = func() any {
 		return &events.Archive{
 			JID:       target,
 			Timestamp: when.Add(2 * time.Minute),
@@ -1687,7 +1687,7 @@ func TestArchiveChatReplaysEventDispatchedAfterWriteCompletion(t *testing.T) {
 	if !required {
 		t.Fatal("post-write recovery debt was cleared before delayed dispatch")
 	}
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		if !fullSync {
 			t.Errorf("recovery fetch fullSync = false")
 		}
@@ -1733,7 +1733,7 @@ func TestConcurrentChatStateWriteCannotReplaySnapshotFromBeforeEarlierWrite(t *t
 	firstWriteStarted := make(chan struct{})
 	releaseFirstWrite := make(chan struct{})
 	var writeCount atomic.Int32
-	f.archiveEvent = func() interface{} {
+	f.archiveEvent = func() any {
 		if writeCount.Add(1) == 1 {
 			close(firstWriteStarted)
 			<-releaseFirstWrite
@@ -1743,7 +1743,7 @@ func TestConcurrentChatStateWriteCannotReplaySnapshotFromBeforeEarlierWrite(t *t
 
 	secondFetchStarted := make(chan struct{})
 	var fetchCount atomic.Int32
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		if fetchCount.Add(1) != 2 {
 			return nil
 		}
@@ -1824,7 +1824,7 @@ func TestArchiveChatPersistsPostSendEventsBeforeClearingIntent(t *testing.T) {
 		}
 	}
 	markerSeen := false
-	f.archiveEvent = func() interface{} {
+	f.archiveEvent = func() any {
 		var err error
 		markerSeen, err = a.db.AppStateRecoveryRequired(string(appstate.WAPatchRegularLow))
 		if err != nil {
@@ -1901,7 +1901,7 @@ func TestArchiveChatMarkerFailureReplaysReentrantLiveEventInOrder(t *testing.T) 
 	a := newTestApp(t)
 	f := newFakeWA()
 	a.wa = f
-	handlerID := f.AddEventHandler(func(evt interface{}) {
+	handlerID := f.AddEventHandler(func(evt any) {
 		a.handleAppStatePersistenceEvent(context.Background(), evt, nil)
 	})
 	defer f.RemoveEventHandler(handlerID)
@@ -1919,7 +1919,7 @@ func TestArchiveChatMarkerFailureReplaysReentrantLiveEventInOrder(t *testing.T) 
 		t.Fatalf("sql.Open: %v", err)
 	}
 	defer raw.Close()
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		if _, err := raw.Exec(`
 			CREATE TRIGGER fail_live_recovery_intent
 			BEFORE INSERT ON app_state_recovery_intents
@@ -1978,7 +1978,7 @@ func TestMuteChatPersistsOtherAppStateDeltasFetchedBeforeWrite(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertMessage: %v", err)
 	}
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		return &events.DeleteForMe{
 			ChatJID:   pending,
 			MessageID: "pending-delete",
@@ -2083,7 +2083,7 @@ func TestArchiveChatWaitsForFullReplayPersistence(t *testing.T) {
 	}
 	replayStarted := make(chan struct{})
 	releaseReplay := make(chan struct{})
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		if !fullSync {
 			return nil
 		}
@@ -2166,7 +2166,7 @@ func TestArchiveChatReplaysAfterRecoveryPersistenceFailure(t *testing.T) {
 		fmt.Errorf("failed to verify regular_low patch: %w", appstate.ErrMismatchingLTHash),
 		nil,
 	}
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		if !fullSync {
 			return nil
 		}
@@ -2197,7 +2197,7 @@ func TestArchiveChatReplaysAfterRecoveryPersistenceFailure(t *testing.T) {
 	}
 	defer reopened.Close()
 	replay := newFakeWA()
-	replay.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	replay.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		if name != string(appstate.WAPatchRegularLow) || !fullSync || onlyIfNotSynced {
 			return nil
 		}
@@ -2262,7 +2262,7 @@ func TestArchiveChatMarksReplayAfterDeltaPersistenceFailure(t *testing.T) {
 	`); err != nil {
 		t.Fatalf("create failure trigger: %v", err)
 	}
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		return &events.Archive{
 			JID:       remoteChat,
 			Timestamp: when.Add(time.Minute),
@@ -2311,7 +2311,7 @@ func TestArchiveChatUsesSynchronousFullReplayForMismatch(t *testing.T) {
 	f := newFakeWA()
 	a.wa = f
 	var recoveries sync.Map
-	handlerID := f.AddEventHandler(func(evt interface{}) {
+	handlerID := f.AddEventHandler(func(evt any) {
 		if syncErr, ok := evt.(*events.AppStateSyncError); ok {
 			a.handleAppStateSyncError(context.Background(), syncErr, &recoveries)
 		}
@@ -2613,7 +2613,7 @@ func TestChatStateSerializationRespectsContextCancellation(t *testing.T) {
 	}
 	replayStarted := make(chan struct{})
 	releaseReplay := make(chan struct{})
-	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) interface{} {
+	f.appStateFetchEvent = func(name string, fullSync, onlyIfNotSynced bool) any {
 		if fullSync {
 			close(replayStarted)
 			<-releaseReplay
@@ -2819,16 +2819,17 @@ func TestSyncStoresLiveAndHistoryMessages(t *testing.T) {
 		},
 	}
 
-	f.connectEvents = []interface{}{live, history}
+	f.connectEvents = []any{live, history}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		cancel()
-	}()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
 	res, err := a.Sync(ctx, SyncOptions{
 		Mode:    SyncModeFollow,
 		AllowQR: false,
+		AfterConnect: func(context.Context) error {
+			cancel()
+			return nil
+		},
 	})
 	if err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -2850,7 +2851,7 @@ func TestSyncDownloadsHistoryNotificationBeforeProcessing(t *testing.T) {
 	base := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
 	syncType := waE2E.HistorySyncType_INITIAL_BOOTSTRAP
 	notif := &waE2E.HistorySyncNotification{SyncType: &syncType}
-	f.connectEvents = []interface{}{&events.Message{
+	f.connectEvents = []any{&events.Message{
 		Message: &waProto.Message{
 			ProtocolMessage: &waProto.ProtocolMessage{
 				HistorySyncNotification: notif,
@@ -3183,16 +3184,17 @@ func TestSyncStoresDisplayText(t *testing.T) {
 		},
 	}
 
-	f.connectEvents = []interface{}{textMsg, imageMsg, replyMsg, reactionMsg}
+	f.connectEvents = []any{textMsg, imageMsg, replyMsg, reactionMsg}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		cancel()
-	}()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
 	res, err := a.Sync(ctx, SyncOptions{
 		Mode:    SyncModeFollow,
 		AllowQR: false,
+		AfterConnect: func(context.Context) error {
+			cancel()
+			return nil
+		},
 	})
 	if err != nil {
 		t.Fatalf("Sync: %v", err)
@@ -3308,7 +3310,7 @@ func TestSyncMediaEnqueueUsesBoundedBackpressure(t *testing.T) {
 	}
 
 	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	for i := 0; i < 600; i++ {
+	for i := range 600 {
 		f.connectEvents = append(f.connectEvents, &events.Message{
 			Info: types.MessageInfo{
 				MessageSource: types.MessageSource{
@@ -3377,7 +3379,7 @@ func TestSyncOnceDrainsMediaBeforeExit(t *testing.T) {
 	const n = 12
 	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	ids := make([]string, 0, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		id := fmt.Sprintf("media-%02d", i)
 		ids = append(ids, id)
 		f.connectEvents = append(f.connectEvents, &events.Message{

--- a/internal/app/unhandled_payload_warning_test.go
+++ b/internal/app/unhandled_payload_warning_test.go
@@ -63,7 +63,7 @@ func TestHistorySyncBoundsUnhandledPayloadWarnings(t *testing.T) {
 		t.Fatalf("stored messages = %d, want %d", got, messageCount)
 	}
 	var detailed, summaries int
-	for _, line := range strings.Split(strings.TrimSpace(eventsOut.String()), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(eventsOut.String()), "\n") {
 		var event struct {
 			Event string         `json:"event"`
 			Data  map[string]any `json:"data"`

--- a/internal/app/webhook_events.go
+++ b/internal/app/webhook_events.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -35,7 +36,7 @@ type SyncWebhookEventSet map[SyncWebhookEventKind]bool
 // empty value means the default: messages only.
 func ParseSyncWebhookEvents(raw string) (SyncWebhookEventSet, error) {
 	set := SyncWebhookEventSet{}
-	for _, part := range strings.Split(raw, ",") {
+	for part := range strings.SplitSeq(raw, ",") {
 		kind := SyncWebhookEventKind(strings.ToLower(strings.TrimSpace(part)))
 		if kind == "" {
 			continue
@@ -52,12 +53,7 @@ func ParseSyncWebhookEvents(raw string) (SyncWebhookEventSet, error) {
 }
 
 func (k SyncWebhookEventKind) valid() bool {
-	for _, known := range syncWebhookEventKinds {
-		if k == known {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(syncWebhookEventKinds, k)
 }
 
 func syncWebhookEventNames() []string {

--- a/internal/app/webhook_events_test.go
+++ b/internal/app/webhook_events_test.go
@@ -321,7 +321,7 @@ func assertSyncWebhookPayloadJIDs(t *testing.T, payload any, want string, paths 
 	}
 	for _, path := range paths {
 		value := decoded
-		for _, part := range strings.Split(path, ".") {
+		for part := range strings.SplitSeq(path, ".") {
 			switch current := value.(type) {
 			case map[string]any:
 				value = current[part]
@@ -361,7 +361,6 @@ func TestPostSyncWebhookEventSignsNewEventKinds(t *testing.T) {
 	}
 
 	for _, event := range events {
-		event := event
 		t.Run(string(event.Kind), func(t *testing.T) {
 			var body []byte
 			var signature string
@@ -545,7 +544,7 @@ func TestWebhookEventsOptInDeliversAllThreeKinds(t *testing.T) {
 	})
 
 	seen := map[string]bool{}
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var payload struct {
 			EventType string
 		}

--- a/internal/out/out.go
+++ b/internal/out/out.go
@@ -7,12 +7,12 @@ import (
 )
 
 type envelope struct {
-	Success bool        `json:"success"`
-	Data    interface{} `json:"data"`
-	Error   *string     `json:"error"`
+	Success bool    `json:"success"`
+	Data    any     `json:"data"`
+	Error   *string `json:"error"`
 }
 
-func WriteJSON(w io.Writer, data interface{}) error {
+func WriteJSON(w io.Writer, data any) error {
 	b, err := json.Marshal(envelope{Success: true, Data: data})
 	if err != nil {
 		return err

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -219,7 +219,7 @@ func rank(query string, haystacks ...string) int {
 }
 
 func hasWordPrefix(h, q string) bool {
-	for _, word := range strings.Fields(h) {
+	for word := range strings.FieldsSeq(h) {
 		if strings.HasPrefix(word, q) {
 			return true
 		}

--- a/internal/store/calls.go
+++ b/internal/store/calls.go
@@ -47,7 +47,7 @@ func (d *DB) UpsertCallEvent(p UpsertCallEventParams) error {
 		p.DurationSecs = 0
 	}
 
-	var participantsJSON interface{}
+	var participantsJSON any
 	if len(p.Participants) > 0 {
 		if b, err := json.Marshal(p.Participants); err == nil {
 			participantsJSON = string(b)
@@ -117,7 +117,7 @@ func (d *DB) singleCallEventRow(chatJID, callID, eventType string) (int64, bool,
 	return ids[0], true, nil
 }
 
-func (d *DB) updateCallEventRow(rowID int64, p UpsertCallEventParams, chatJID, callID, eventType string, ts int64, participantsJSON interface{}) error {
+func (d *DB) updateCallEventRow(rowID int64, p UpsertCallEventParams, chatJID, callID, eventType string, ts int64, participantsJSON any) error {
 	res, err := d.sql.Exec(`
 			UPDATE call_events SET
 				chat_jid=?,
@@ -167,7 +167,7 @@ func (d *DB) DeleteCallEvents(p DeleteCallEventsParams) (int64, error) {
 		return 0, fmt.Errorf("chat JID is required")
 	}
 	query := "DELETE FROM call_events WHERE chat_jid = ? AND event_type = 'call_log'"
-	args := []interface{}{chatJID}
+	args := []any{chatJID}
 	if direction := strings.TrimSpace(p.Direction); direction != "" {
 		query += " AND direction = ?"
 		args = append(args, direction)
@@ -190,7 +190,7 @@ func (d *DB) ListCallEvents(p ListCallEventsParams) ([]CallEvent, error) {
 		       ts, COALESCE(participants,'')
 		FROM call_events
 		WHERE 1=1`
-	var args []interface{}
+	var args []any
 	query, args = appendStringFilter(query, args, "chat_jid", p.ChatJID, p.ChatJIDs)
 	if p.After != nil {
 		query += " AND ts > ?"

--- a/internal/store/chats.go
+++ b/internal/store/chats.go
@@ -54,7 +54,7 @@ func (d *DB) ListChatsFiltered(f ChatListFilter) ([]Chat, error) {
 		f.Limit = 50
 	}
 	q := `SELECT jid, kind, COALESCE(name,''), COALESCE(last_message_ts,0), COALESCE(archived,0), COALESCE(pinned,0), COALESCE(muted_until,0), COALESCE(unread,0), COALESCE(unread_count,0) FROM chats WHERE 1=1`
-	var args []interface{}
+	var args []any
 	if strings.TrimSpace(f.Query) != "" {
 		q += ` AND (LOWER(name) LIKE LOWER(?) ESCAPE '\' OR LOWER(jid) LIKE LOWER(?) ESCAPE '\')`
 		needle := likeContains(f.Query)
@@ -343,11 +343,7 @@ func chatFromRow(row storedb.GetChatRow) Chat {
 
 func applyChatUnread(c *Chat, unread, unreadCount int) {
 	c.Unread = unread != 0
-	if unreadCount > 0 {
-		c.UnreadCount = unreadCount
-	} else {
-		c.UnreadCount = 0
-	}
+	c.UnreadCount = max(unreadCount, 0)
 }
 
 func sqlNullInt64(n int64) sql.NullInt64 {

--- a/internal/store/groups.go
+++ b/internal/store/groups.go
@@ -136,7 +136,7 @@ func (d *DB) ListGroups(query string, limit int) ([]Group, error) {
 		limit = 50
 	}
 	q := `SELECT jid, COALESCE(name,''), COALESCE(owner_jid,''), is_parent, COALESCE(linked_parent_jid,''), COALESCE(created_ts,0), COALESCE(left_at,0), updated_at FROM groups WHERE left_at IS NULL`
-	var args []interface{}
+	var args []any
 	if strings.TrimSpace(query) != "" {
 		needle := likeContains(query)
 		q += ` AND (LOWER(name) LIKE LOWER(?) ESCAPE '\' OR LOWER(jid) LIKE LOWER(?) ESCAPE '\')`

--- a/internal/store/history.go
+++ b/internal/store/history.go
@@ -54,7 +54,7 @@ func (d *DB) ListHistoryCoverage(p ListHistoryCoverageParams) ([]HistoryCoverage
 			GROUP BY chat_jid
 		) ms ON ms.chat_jid = c.jid
 		WHERE 1=1`
-	args := make([]interface{}, 0, 8)
+	args := make([]any, 0, 8)
 
 	if q := strings.TrimSpace(p.Query); q != "" {
 		needle := likeContains(q)

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -375,7 +375,7 @@ func (d *DB) ListMessages(p ListMessagesParams) ([]Message, error) {
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		LEFT JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
 		WHERE m.deleted_at IS NULL`
-	var args []interface{}
+	var args []any
 	query, args = appendStringFilter(query, args, "m.chat_jid", p.ChatJID, p.ChatJIDs)
 	if p.After != nil {
 		query += " AND m.ts > ?"
@@ -408,7 +408,7 @@ func (d *DB) ListMessages(p ListMessagesParams) ([]Message, error) {
 	return d.scanMessages(query, args...)
 }
 
-func appendStringFilter(query string, args []interface{}, column, value string, values []string) (string, []interface{}) {
+func appendStringFilter(query string, args []any, column, value string, values []string) (string, []any) {
 	filterValues := uniqueNonEmptyStrings(append([]string{value}, values...))
 	switch len(filterValues) {
 	case 0:
@@ -552,7 +552,7 @@ func (d *DB) MessageContext(chatJID, msgID string, before, after int) ([]Message
 	return out, nil
 }
 
-func (d *DB) scanMessages(query string, args ...interface{}) ([]Message, error) {
+func (d *DB) scanMessages(query string, args ...any) ([]Message, error) {
 	rows, err := d.sql.Query(query, args...)
 	if err != nil {
 		return nil, err

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -63,7 +63,7 @@ func (d *DB) searchLIKE(p SearchMessagesParams) ([]Message, error) {
 	WHERE m.deleted_at IS NULL AND (LOWER(m.text) LIKE LOWER(?) ESCAPE '\' OR LOWER(m.display_text) LIKE LOWER(?) ESCAPE '\' OR LOWER(m.media_caption) LIKE LOWER(?) ESCAPE '\' OR LOWER(m.filename) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(m.chat_name,'')) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(m.sender_name,'')) LIKE LOWER(?) ESCAPE '\' OR LOWER(COALESCE(c.name,'')) LIKE LOWER(?) ESCAPE '\')`
 	// Escape wildcards before wrapping in % so user input is literal (#56).
 	needle := likeContains(p.Query)
-	args := []interface{}{needle, needle, needle, needle, needle, needle, needle}
+	args := []any{needle, needle, needle, needle, needle, needle, needle}
 	query, args = applyMessageFilters(query, args, p)
 	query += " ORDER BY m.ts DESC, m.rowid DESC LIMIT ?"
 	args = append(args, p.Limit)
@@ -99,14 +99,14 @@ func (d *DB) searchFTS(p SearchMessagesParams) ([]Message, error) {
 	// Sanitize to prevent FTS5 query-syntax injection (#57).
 	// Each token is individually quoted so multi-word queries still work
 	// as implicit AND (both words present, any order).
-	args := []interface{}{sanitizeFTSQuery(p.Query)}
+	args := []any{sanitizeFTSQuery(p.Query)}
 	query, args = applyMessageFilters(query, args, p)
 	query += " ORDER BY bm25(messages_fts), m.rowid DESC LIMIT ?"
 	args = append(args, p.Limit)
 	return d.scanMessages(query, args...)
 }
 
-func applyMessageFilters(query string, args []interface{}, p SearchMessagesParams) (string, []interface{}) {
+func applyMessageFilters(query string, args []any, p SearchMessagesParams) (string, []any) {
 	query, args = appendStringFilter(query, args, "m.chat_jid", p.ChatJID, p.ChatJIDs)
 	if strings.TrimSpace(p.From) != "" {
 		query += " AND m.sender_jid = ?"

--- a/internal/store/starred.go
+++ b/internal/store/starred.go
@@ -61,7 +61,7 @@ func (d *DB) ListStarredMessages(p ListStarredMessagesParams) ([]Message, error)
 		LEFT JOIN chats c ON c.jid = m.chat_jid
 		JOIN starred s ON s.chat_jid = m.chat_jid AND s.msg_id = m.msg_id
 		WHERE m.deleted_at IS NULL`
-	var args []interface{}
+	var args []any
 	query, args = appendStringFilter(query, args, "m.chat_jid", p.ChatJID, p.ChatJIDs)
 	if p.After != nil {
 		query += " AND s.starred_at > ?"

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -176,7 +176,7 @@ func boolToInt64(b bool) int64 {
 	return 0
 }
 
-func nullIfEmpty(s string) interface{} {
+func nullIfEmpty(s string) any {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return nil

--- a/internal/wa/appstate.go
+++ b/internal/wa/appstate.go
@@ -20,7 +20,7 @@ func (c *Client) SendAppState(ctx context.Context, patch appstate.PatchInfo) err
 	return cli.SendAppState(ctx, patch)
 }
 
-func (c *Client) sendAppStateWithBoundary(ctx context.Context, patch appstate.PatchInfo, beforeApply func()) ([]interface{}, error) {
+func (c *Client) sendAppStateWithBoundary(ctx context.Context, patch appstate.PatchInfo, beforeApply func()) ([]any, error) {
 	// Reserve wacli persistence before whatsmeow can advance app state. The
 	// durable recovery intent remains after return because canonical sends
 	// dispatch their resulting events asynchronously.
@@ -28,18 +28,18 @@ func (c *Client) sendAppStateWithBoundary(ctx context.Context, patch appstate.Pa
 	return nil, c.SendAppState(ctx, patch)
 }
 
-func (c *Client) ArchiveChat(ctx context.Context, target types.JID, archive bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey, beforeApply func()) ([]interface{}, error) {
+func (c *Client) ArchiveChat(ctx context.Context, target types.JID, archive bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey, beforeApply func()) ([]any, error) {
 	return c.sendAppStateWithBoundary(ctx, appstate.BuildArchive(target, archive, lastMsgTS, lastMsgKey), beforeApply)
 }
 
-func (c *Client) PinChat(ctx context.Context, target types.JID, pin bool, beforeApply func()) ([]interface{}, error) {
+func (c *Client) PinChat(ctx context.Context, target types.JID, pin bool, beforeApply func()) ([]any, error) {
 	return c.sendAppStateWithBoundary(ctx, appstate.BuildPin(target, pin), beforeApply)
 }
 
-func (c *Client) MuteChat(ctx context.Context, target types.JID, mute bool, duration time.Duration, beforeApply func()) ([]interface{}, error) {
+func (c *Client) MuteChat(ctx context.Context, target types.JID, mute bool, duration time.Duration, beforeApply func()) ([]any, error) {
 	return c.sendAppStateWithBoundary(ctx, appstate.BuildMute(target, mute, duration), beforeApply)
 }
 
-func (c *Client) MarkChatAsRead(ctx context.Context, target types.JID, read bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey, beforeApply func()) ([]interface{}, error) {
+func (c *Client) MarkChatAsRead(ctx context.Context, target types.JID, read bool, lastMsgTS time.Time, lastMsgKey *waCommon.MessageKey, beforeApply func()) ([]any, error) {
 	return c.sendAppStateWithBoundary(ctx, appstate.BuildMarkChatAsRead(target, read, lastMsgTS, lastMsgKey), beforeApply)
 }

--- a/internal/wa/calls.go
+++ b/internal/wa/calls.go
@@ -59,7 +59,7 @@ func extractCallLog(m *waProto.Message, pm *ParsedMessage) {
 	}
 }
 
-func ParseLiveCallEvent(evt interface{}, self types.JID, alternateSelf ...types.JID) (ParsedCallEvent, bool) {
+func ParseLiveCallEvent(evt any, self types.JID, alternateSelf ...types.JID) (ParsedCallEvent, bool) {
 	switch v := evt.(type) {
 	case *events.CallOffer:
 		return callEventFromMeta(v.BasicCallMeta, self, "offer", "", "", mediaFromCallNode(v.Data), ""), true
@@ -84,7 +84,7 @@ func ParseLiveCallEvent(evt interface{}, self types.JID, alternateSelf ...types.
 	}
 }
 
-func ParseCallLogDeleteEvent(evt interface{}) (ParsedCallDelete, bool) {
+func ParseCallLogDeleteEvent(evt any) (ParsedCallDelete, bool) {
 	v, ok := evt.(*events.AppState)
 	if !ok || v == nil || v.SyncActionValue == nil || v.GetDeleteIndividualCallLog() == nil {
 		return ParsedCallDelete{}, false

--- a/internal/wa/client.go
+++ b/internal/wa/client.go
@@ -261,7 +261,7 @@ func qrChannelEventError(evt whatsmeow.QRChannelItem) error {
 	}
 }
 
-func (c *Client) AddEventHandler(handler func(interface{})) uint32 {
+func (c *Client) AddEventHandler(handler func(any)) uint32 {
 	c.mu.Lock()
 	cli := c.client
 	c.mu.Unlock()
@@ -716,7 +716,7 @@ func (c *Client) FetchAppState(ctx context.Context, name string, fullSync, onlyI
 // FetchAppStateEvents fetches one collection without globally dispatching the
 // resulting events, so callers can persist that exact collection atomically
 // with their own recovery marker protocol.
-func (c *Client) FetchAppStateEvents(ctx context.Context, name string, fullSync, onlyIfNotSynced bool) ([]interface{}, error) {
+func (c *Client) FetchAppStateEvents(ctx context.Context, name string, fullSync, onlyIfNotSynced bool) ([]any, error) {
 	c.mu.Lock()
 	cli := c.client
 	c.mu.Unlock()
@@ -921,7 +921,7 @@ func (c *Client) SetProfilePicture(ctx context.Context, avatar []byte) (string, 
 		return "", fmt.Errorf("not connected")
 	}
 
-	var content interface{}
+	var content any
 	if avatar != nil {
 		content = []waBinary.Node{{
 			Tag:     "picture",

--- a/internal/wa/logger.go
+++ b/internal/wa/logger.go
@@ -43,10 +43,10 @@ func newWhatsmeowLogger(module, minLevel string, w io.Writer) *whatsmeowLogger {
 	}
 }
 
-func (l *whatsmeowLogger) Errorf(msg string, args ...interface{}) { l.outputf("ERROR", msg, args...) }
-func (l *whatsmeowLogger) Warnf(msg string, args ...interface{})  { l.outputf("WARN", msg, args...) }
-func (l *whatsmeowLogger) Infof(msg string, args ...interface{})  { l.outputf("INFO", msg, args...) }
-func (l *whatsmeowLogger) Debugf(msg string, args ...interface{}) { l.outputf("DEBUG", msg, args...) }
+func (l *whatsmeowLogger) Errorf(msg string, args ...any) { l.outputf("ERROR", msg, args...) }
+func (l *whatsmeowLogger) Warnf(msg string, args ...any)  { l.outputf("WARN", msg, args...) }
+func (l *whatsmeowLogger) Infof(msg string, args ...any)  { l.outputf("INFO", msg, args...) }
+func (l *whatsmeowLogger) Debugf(msg string, args ...any) { l.outputf("DEBUG", msg, args...) }
 
 func (l *whatsmeowLogger) Sub(module string) waLog.Logger {
 	return &whatsmeowLogger{
@@ -57,7 +57,7 @@ func (l *whatsmeowLogger) Sub(module string) waLog.Logger {
 	}
 }
 
-func (l *whatsmeowLogger) outputf(level, msg string, args ...interface{}) {
+func (l *whatsmeowLogger) outputf(level, msg string, args ...any) {
 	levelValue, ok := whatsmeowLogLevels[level]
 	if !ok || levelValue < l.min {
 		return

--- a/internal/wa/media.go
+++ b/internal/wa/media.go
@@ -341,10 +341,7 @@ func (f *limitedDownloadFile) ReadFrom(r io.Reader) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	remaining := f.max - off
-	if remaining < 0 {
-		remaining = 0
-	}
+	remaining := max(f.max-off, 0)
 	n, err := io.Copy(f.File, io.LimitReader(r, remaining))
 	f.noteWritten(off + n)
 	if err != nil {

--- a/internal/wa/messages_contacts.go
+++ b/internal/wa/messages_contacts.go
@@ -2,6 +2,7 @@ package wa
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	waProto "go.mau.fi/whatsmeow/binary/proto"
@@ -108,10 +109,8 @@ func formatContactLine(name string, phones []string) string {
 }
 
 func appendUnique(values []string, value string) []string {
-	for _, existing := range values {
-		if existing == value {
-			return values
-		}
+	if slices.Contains(values, value) {
+		return values
 	}
 	return append(values, value)
 }


### PR DESCRIPTION
Use `any`, integer ranges, `min`/`max`, `slices.Contains`, and string sequence iterators where they directly replace older idioms at the existing Go 1.27 minimum. Generated code and public data formats remain unchanged.

Three sync tests previously canceled after an arbitrary 100 ms, allowing a slow startup to preempt the events they asserted. Cancel from `AfterConnect`, after the fake client has synchronously delivered its configured events, and close both stderr pipe descriptors even when a test fails. All original assertions remain.

Validation:
- `pnpm format:check && pnpm lint && pnpm test && pnpm build && pnpm docs:site && git diff --check` passed, including both Go variants and all 26 Node tests.
- The panic-recovery, live/history-storage, and display-text tests each passed 20 repetitions with FTS enabled.
- Isolated Codex autoreview: scoped-clean at P0–P2.

Built-CLI proof: base and candidate binaries compiled with cgo and `sqlite_fts5` produced identical exit codes, stdout, and stderr across 53 invocations against a temporary synthetic three-message SQLite/FTS store: all message help pages, date-filtered list/search/starred/export, show/context, and read-only mutation rejection. The store was removed afterward; this proof used no live WhatsApp session or network connection.
