### PR TITLE
refactor: remove production helpers used only by tests

### DIFF
--- a/cmd/wacli/contacts.go
+++ b/cmd/wacli/contacts.go
@@ -237,8 +237,8 @@ func newContactsAliasCmd(flags *rootFlags) *cobra.Command {
 		},
 	})
 
-	_ = cmd.PersistentFlags().String("jid", "", "contact JID")
-	_ = cmd.PersistentFlags().String("alias", "", "alias")
+	cmd.PersistentFlags().String("jid", "", "contact JID")
+	cmd.PersistentFlags().String("alias", "", "alias")
 	return cmd
 }
 
@@ -306,7 +306,7 @@ func newContactsTagsCmd(flags *rootFlags) *cobra.Command {
 		},
 	})
 
-	_ = cmd.PersistentFlags().String("jid", "", "contact JID")
-	_ = cmd.PersistentFlags().String("tag", "", "tag")
+	cmd.PersistentFlags().String("jid", "", "contact JID")
+	cmd.PersistentFlags().String("tag", "", "tag")
 	return cmd
 }

--- a/cmd/wacli/messages_delete.go
+++ b/cmd/wacli/messages_delete.go
@@ -235,11 +235,6 @@ func loadMessageRevokeTarget(ctx context.Context, a *app.App, chat, id string) (
 	return store.Message{}, chatJID, false, nil
 }
 
-func deleteLocalMediaIfRequested(deleteMedia bool, localPath string) (bool, error) {
-	deleted, err := deleteLocalMediaPathsIfRequested(deleteMedia, []string{localPath})
-	return deleted > 0, err
-}
-
 func deleteLocalMediaPathsIfRequested(deleteMedia bool, paths []string) (int, error) {
 	if !deleteMedia {
 		return 0, nil

--- a/cmd/wacli/messages_test.go
+++ b/cmd/wacli/messages_test.go
@@ -553,28 +553,28 @@ func TestWriteMessageShowIncludesForwardedMetadata(t *testing.T) {
 	}
 }
 
-func TestDeleteLocalMediaIfRequestedReportsActualRemoval(t *testing.T) {
+func TestDeleteLocalMediaPathsIfRequestedReportsActualRemoval(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "media.bin")
 	if err := os.WriteFile(path, []byte("media"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	deleted, err := deleteLocalMediaIfRequested(true, path)
+	deleted, err := deleteLocalMediaPathsIfRequested(true, []string{path})
 	if err != nil {
-		t.Fatalf("deleteLocalMediaIfRequested: %v", err)
+		t.Fatalf("deleteLocalMediaPathsIfRequested: %v", err)
 	}
-	if !deleted {
-		t.Fatal("deleted = false, want true")
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
 	}
-	deleted, err = deleteLocalMediaIfRequested(true, path)
+	deleted, err = deleteLocalMediaPathsIfRequested(true, []string{path})
 	if err != nil {
 		t.Fatalf("delete stale media path: %v", err)
 	}
-	if deleted {
-		t.Fatal("deleted stale path = true, want false")
+	if deleted != 0 {
+		t.Fatalf("deleted stale path = %d, want 0", deleted)
 	}
-	deleted, err = deleteLocalMediaIfRequested(false, path)
-	if err != nil || deleted {
-		t.Fatalf("delete disabled = %v, %v; want false, nil", deleted, err)
+	deleted, err = deleteLocalMediaPathsIfRequested(false, []string{path})
+	if err != nil || deleted != 0 {
+		t.Fatalf("delete disabled = %d, %v; want 0, nil", deleted, err)
 	}
 }
 

--- a/cmd/wacli/send.go
+++ b/cmd/wacli/send.go
@@ -482,10 +482,6 @@ func decodeMessageEscapes(s string) (string, error) {
 	return b.String(), nil
 }
 
-func buildTextMessage(db *store.DB, to types.JID, text, replyTo, replyToSender string, preview *linkpreview.Preview, mentionedJIDs []string) (*waProto.Message, bool, error) {
-	return buildTextMessageWithSelf(db, to, types.EmptyJID, text, replyTo, replyToSender, "", preview, mentionedJIDs)
-}
-
 func buildTextMessageWithSelf(db *store.DB, to, aliasTo types.JID, text, replyTo, replyToSender, selfJID string, preview *linkpreview.Preview, mentionedJIDs []string) (*waProto.Message, bool, error) {
 	info, err := buildTextContextInfo(db, to, aliasTo, replyTo, replyToSender, selfJID, mentionedJIDs)
 	if err != nil {

--- a/cmd/wacli/send_sticker.go
+++ b/cmd/wacli/send_sticker.go
@@ -126,11 +126,6 @@ func newStickerMessage(up whatsmeow.UploadResponse, info *waProto.ContextInfo, m
 	}
 }
 
-func isWebPStickerData(data []byte) bool {
-	_, err := parseWebPStickerMetadata(data)
-	return err == nil
-}
-
 func validateWebPSticker(data []byte) (webPStickerMetadata, error) {
 	meta, err := parseWebPStickerMetadata(data)
 	if err != nil {

--- a/cmd/wacli/send_sticker_test.go
+++ b/cmd/wacli/send_sticker_test.go
@@ -33,9 +33,9 @@ func TestSendStickerCommandExposesSharedSendFlags(t *testing.T) {
 	}
 }
 
-func TestIsWebPStickerData(t *testing.T) {
+func TestParseWebPStickerMetadataRejectsInvalidHeaders(t *testing.T) {
 	valid := testWebPVP8X(512, 512, false, nil)
-	if !isWebPStickerData(valid) {
+	if _, err := parseWebPStickerMetadata(valid); err != nil {
 		t.Fatalf("valid WebP header was rejected")
 	}
 	for _, data := range [][]byte{
@@ -43,7 +43,7 @@ func TestIsWebPStickerData(t *testing.T) {
 		[]byte("RIFF\x10\x00\x00\x00PNG "),
 		[]byte("not webp"),
 	} {
-		if isWebPStickerData(data) {
+		if _, err := parseWebPStickerMetadata(data); err == nil {
 			t.Fatalf("invalid WebP header was accepted: %q", string(data))
 		}
 	}

--- a/cmd/wacli/send_test.go
+++ b/cmd/wacli/send_test.go
@@ -876,7 +876,7 @@ func TestBuildTextMessageUsesPlainConversationWithoutReplyOrPreview(t *testing.T
 	db := openSendTestDB(t)
 	chat := types.JID{User: "15551234567", Server: types.DefaultUserServer}
 
-	msg, plain, err := buildTextMessage(db, chat, "hello", "", "", nil, nil)
+	msg, plain, err := buildTextMessageWithSelf(db, chat, types.EmptyJID, "hello", "", "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("buildTextMessage: %v", err)
 	}
@@ -893,7 +893,7 @@ func TestBuildTextMessageAttachesMentions(t *testing.T) {
 	chat := types.JID{User: "12345", Server: types.GroupServer}
 	mentions := []string{"15551234567@s.whatsapp.net", "15557654321@s.whatsapp.net"}
 
-	msg, plain, err := buildTextMessage(db, chat, "hey @15551234567", "", "", nil, mentions)
+	msg, plain, err := buildTextMessageWithSelf(db, chat, types.EmptyJID, "hey @15551234567", "", "", "", nil, mentions)
 	if err != nil {
 		t.Fatalf("buildTextMessage: %v", err)
 	}
@@ -1099,7 +1099,7 @@ func TestBuildTextMessageCombinesReplyAndMentions(t *testing.T) {
 		t.Fatalf("UpsertMessage: %v", err)
 	}
 
-	msg, plain, err := buildTextMessage(db, chat, "replying @15551234567", "quoted", "+15557654321", nil, []string{"15551234567@s.whatsapp.net"})
+	msg, plain, err := buildTextMessageWithSelf(db, chat, types.EmptyJID, "replying @15551234567", "quoted", "+15557654321", "", nil, []string{"15551234567@s.whatsapp.net"})
 	if err != nil {
 		t.Fatalf("buildTextMessage: %v", err)
 	}
@@ -1131,7 +1131,7 @@ func TestBuildTextMessageAttachesLinkPreview(t *testing.T) {
 		Thumbnail:   []byte("jpeg"),
 	}
 
-	msg, plain, err := buildTextMessage(db, chat, "see https://example.com/post", "", "", preview, nil)
+	msg, plain, err := buildTextMessageWithSelf(db, chat, types.EmptyJID, "see https://example.com/post", "", "", "", preview, nil)
 	if err != nil {
 		t.Fatalf("buildTextMessage: %v", err)
 	}

--- a/cmd/wacli/store_cleanup.go
+++ b/cmd/wacli/store_cleanup.go
@@ -37,8 +37,6 @@ Use --dry-run to preview what would be deleted.`,
 			}
 			defer closeApp(a, lk)
 
-			_ = ctx
-
 			chats, err := a.DB().ListChatsOlderThan(days)
 			if err != nil {
 				return err

--- a/cmd/wacli/store_stats.go
+++ b/cmd/wacli/store_stats.go
@@ -23,8 +23,6 @@ func newStoreStatsCmd(flags *rootFlags) *cobra.Command {
 			}
 			defer closeApp(a, lk)
 
-			_ = ctx
-
 			chats, err := a.DB().CountChats()
 			if err != nil {
 				return err

--- a/internal/app/app_state.go
+++ b/internal/app/app_state.go
@@ -39,23 +39,6 @@ func (s *appStatePersistenceSequencer) reserveTask(blocksEarlier bool) uint64 {
 	return ticket
 }
 
-func (s *appStatePersistenceSequencer) enqueue(run func()) uint64 {
-	s.mu.Lock()
-	s.initLocked()
-	ticket := s.next
-	s.next++
-	s.tasks[ticket] = &appStatePersistenceTask{ready: true, run: run}
-	start := !s.running && ticket == s.serving
-	if start {
-		s.running = true
-	}
-	s.mu.Unlock()
-	if start {
-		s.drainThrough(ticket)
-	}
-	return ticket
-}
-
 func (s *appStatePersistenceSequencer) complete(ticket uint64, run func()) uint64 {
 	return s.completeTask(ticket, run, true)
 }

--- a/internal/app/app_state_test.go
+++ b/internal/app/app_state_test.go
@@ -21,7 +21,7 @@ func TestAppStatePersistenceSequencerPreservesReservationOrder(t *testing.T) {
 	}
 
 	ticket := sequencer.reserve()
-	sequencer.enqueue(record(2))
+	enqueueAppStateTask(&sequencer, record(2))
 	frontier := sequencer.complete(ticket, record(1))
 	if err := sequencer.waitThrough(context.Background(), frontier); err != nil {
 		t.Fatalf("waitThrough: %v", err)
@@ -41,7 +41,7 @@ func TestAppStatePersistenceSequencerDoesNotOvertakeLiveEvent(t *testing.T) {
 	releaseLive := make(chan struct{})
 	liveDone := make(chan struct{})
 	go func() {
-		sequencer.enqueue(func() {
+		enqueueAppStateTask(&sequencer, func() {
 			close(liveStarted)
 			<-releaseLive
 			mu.Lock()
@@ -88,7 +88,7 @@ func TestAppStatePersistenceSequencerWaitsForFixedFrontier(t *testing.T) {
 	laterStarted := make(chan struct{})
 	releaseLater := make(chan struct{})
 	laterDone := make(chan struct{})
-	sequencer.enqueue(func() {
+	enqueueAppStateTask(&sequencer, func() {
 		close(laterStarted)
 		<-releaseLater
 		close(laterDone)
@@ -112,7 +112,7 @@ func TestAppCloseDrainsHandedOffAppStatePersistence(t *testing.T) {
 	releaseFirst := make(chan struct{})
 	firstDone := make(chan struct{})
 	go func() {
-		a.appStatePersist.enqueue(func() {
+		enqueueAppStateTask(&a.appStatePersist, func() {
 			close(firstStarted)
 			<-releaseFirst
 		})
@@ -123,7 +123,7 @@ func TestAppCloseDrainsHandedOffAppStatePersistence(t *testing.T) {
 	secondStarted := make(chan struct{})
 	releaseSecond := make(chan struct{})
 	writeErr := make(chan error, 1)
-	a.appStatePersist.enqueue(func() {
+	enqueueAppStateTask(&a.appStatePersist, func() {
 		close(secondStarted)
 		<-releaseSecond
 		writeErr <- a.db.UpsertChat("123@s.whatsapp.net", "dm", "Alice", time.Now().UTC())
@@ -251,4 +251,10 @@ func TestAppStatePersistenceSequencerDoesNotDrainPastUnreadyLiveTask(t *testing.
 	if !reflect.DeepEqual(order, []int{1, 2, 3}) {
 		t.Fatalf("persistence order = %v, want [1 2 3]", order)
 	}
+}
+
+func enqueueAppStateTask(s *appStatePersistenceSequencer, run func()) uint64 {
+	ticket := s.reserve()
+	s.completeOne(ticket, run)
+	return ticket
 }

--- a/internal/app/sync_test.go
+++ b/internal/app/sync_test.go
@@ -1862,7 +1862,7 @@ func TestLocalAppStateWriteFinishesAfterRequestCancellation(t *testing.T) {
 	a := newTestApp(t)
 	blockerStarted := make(chan struct{})
 	releaseBlocker := make(chan struct{})
-	go a.appStatePersist.enqueue(func() {
+	go enqueueAppStateTask(&a.appStatePersist, func() {
 		close(blockerStarted)
 		<-releaseBlocker
 	})

--- a/internal/store/polls.go
+++ b/internal/store/polls.go
@@ -341,11 +341,6 @@ func (d *DB) DeletePoll(chatJID, msgID string) error {
 	return tx.Commit()
 }
 
-// IsPollNotFound is a small convenience predicate.
-func IsPollNotFound(err error) bool {
-	return errors.Is(err, sql.ErrNoRows)
-}
-
 func limitOrAll(limit int) int {
 	if limit > 0 {
 		return limit

--- a/internal/store/polls_test.go
+++ b/internal/store/polls_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"errors"
 	"reflect"
 	"testing"
@@ -361,10 +362,10 @@ func TestPollQueriesHideDeletedMessages(t *testing.T) {
 		t.Fatalf("MarkMessageDeletedForMe: %v", err)
 	}
 
-	if _, err := db.GetPoll("chat@s.whatsapp.net", "revoked"); !IsPollNotFound(err) {
+	if _, err := db.GetPoll("chat@s.whatsapp.net", "revoked"); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("GetPoll revoked err = %v, want not found", err)
 	}
-	if _, err := db.FindPollByMsgID("deleted"); !IsPollNotFound(err) {
+	if _, err := db.FindPollByMsgID("deleted"); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("FindPollByMsgID deleted err = %v, want not found", err)
 	}
 	polls, err := db.ListPolls(PollListFilter{ChatJID: "chat@s.whatsapp.net"})
@@ -424,7 +425,7 @@ func TestPollPayloadCannotReturnAfterMessagePurge(t *testing.T) {
 	if got := countRows(t, db.sql, `SELECT count(*) FROM poll_votes WHERE chat_jid = 'chat@s.whatsapp.net' AND poll_msg_id = 'poll'`); got != 0 {
 		t.Fatalf("restored poll vote rows = %d", got)
 	}
-	if _, err := db.GetPoll(chat, "poll"); !IsPollNotFound(err) {
+	if _, err := db.GetPoll(chat, "poll"); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("GetPoll after purge = %v", err)
 	}
 }
@@ -449,7 +450,7 @@ func TestDeletePollRemovesVotes(t *testing.T) {
 	}
 	if _, err := db.GetPoll("chat@s.whatsapp.net", "P1"); err == nil {
 		t.Fatal("expected GetPoll to return ErrNoRows after delete")
-	} else if !IsPollNotFound(err) {
+	} else if !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("expected sql.ErrNoRows, got %v", err)
 	}
 	votes, err := db.ListPollVotes("chat@s.whatsapp.net", "P1")

--- a/internal/wa/client_test.go
+++ b/internal/wa/client_test.go
@@ -113,7 +113,12 @@ func TestBuildPollCreationMessageSelectsVersion(t *testing.T) {
 			if got := msg.GetPollCreationMessageV3() != nil; got != tt.wantV3 {
 				t.Fatalf("v3 = %t, want %t", got, tt.wantV3)
 			}
-			creation := pickOutboundPollCreation(msg)
+			creation := msg.GetPollCreationMessage()
+			if tt.wantV2 {
+				creation = msg.GetPollCreationMessageV2()
+			} else if tt.wantV3 {
+				creation = msg.GetPollCreationMessageV3()
+			}
 			if creation.GetName() != "Lunch?" {
 				t.Fatalf("name = %q", creation.GetName())
 			}

--- a/internal/wa/polls.go
+++ b/internal/wa/polls.go
@@ -72,19 +72,6 @@ func isCommunityAnnouncementGroup(info *types.GroupInfo) bool {
 	return info != nil && info.IsAnnounce && info.IsParent
 }
 
-func pickOutboundPollCreation(msg *waE2E.Message) *waE2E.PollCreationMessage {
-	if msg == nil {
-		return nil
-	}
-	if msg.GetPollCreationMessage() != nil {
-		return msg.GetPollCreationMessage()
-	}
-	if msg.GetPollCreationMessageV2() != nil {
-		return msg.GetPollCreationMessageV2()
-	}
-	return msg.GetPollCreationMessageV3()
-}
-
 func wrapEphemeralPollMessage(msg *waE2E.Message) *waE2E.Message {
 	if msg == nil {
 		return nil


### PR DESCRIPTION
The dead-code gate included tests, so six obsolete production helpers remained reachable only through their test callers. Remove the wrappers for text-message construction, sticker parsing, single-file deletion, poll lookup errors, and poll-version selection, plus the unused app-state enqueue implementation. Existing tests now call the actual production primitives, including reservation/completion for persistence sequencing. All assertions remain; media deletion now checks the exact count.

Also remove redundant blank assignments in command setup. These are internal-only changes: no public CLI or data-format changes.

Validation:
- Full local gate: `pnpm format:check && pnpm lint && pnpm test && pnpm build && pnpm docs:site && git diff --check`.
- Both `go run golang.org/x/tools/cmd/deadcode@v0.50.0 -tags sqlite_fts5 ./...` and its `-test` variant return no findings.
- Isolated Codex autoreview: scoped-clean at P0–P2.
- Built base/candidate CLIs match exit code, stdout, and stderr for 53 invocations against a temporary synthetic SQLite/FTS store: command help, date-filtered reads and errors, show/context, and read-only mutation guards. The store is removed after the proof; no live WhatsApp session or network connection is used.
