### PR TITLE
fix(messages): decode group content wrappers and invitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Sync: decrypt encrypted message edits in live/history sync and bind updates to the authenticated sender, chat, and target. (#362, #363 - thanks @goutamadwant)
+- Messages: index associated-child and group-status-mention content and group-invite captions during live/history sync. (#365)
 - Sync: repair LTHash mismatches with a durable full refresh before bounded phone recovery, and replay interrupted recovery at startup. (#367, #382 - thanks @shishiv)
 - Auth: retain observed session revocation in auth/doctor diagnostics until confirmed login, and wait for login confirmation before reporting a successful diagnostic connection. (#389 - thanks @0xble)
 - Builds: update pnpm to 12.4.1, share production/test dead-code checks between local and CI gates, validate documentation links in CI, and isolate concurrent Windows lock cross-builds.

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -27,6 +27,7 @@ wacli messages forward --chat JID --id MSG_ID --to RECIPIENT [--pick N] [--post-
 - Falls back to `LIKE` if FTS5 is not available.
 - `--type` accepts `text`, `image`, `video`, `audio`, or `document`.
 - Shared WhatsApp contact cards are stored as searchable text with contact names and phone numbers when WhatsApp includes a vCard payload.
+- Associated-child and group-status-mention wrappers retain their inner text, media, and reply context. Group invitations expose their caption, with the group name as a fallback. These parser fixes apply on re-ingestion; they cannot recover absent payloads or missing decryption keys.
 - Comment payloads retain their inner text or media and their envelope's reply target. Album headers show expected image/video counts; those summaries do not recover missing child captions or undecryptable history.
 - `--starred` restricts list/search results to messages marked as starred by WhatsApp.
 - Time filters accept RFC3339 or `YYYY-MM-DD`.

--- a/internal/app/sync_edits.go
+++ b/internal/app/sync_edits.go
@@ -80,7 +80,9 @@ func containsNestedProtocolMutation(msg *waE2E.Message) bool {
 	if msg.GetProtocolMessage() != nil {
 		return true
 	}
-	return containsNestedProtocolMutation(msg.GetDeviceSentMessage().GetMessage()) ||
+	return containsNestedProtocolMutation(msg.GetAssociatedChildMessage().GetMessage()) ||
+		containsNestedProtocolMutation(msg.GetGroupStatusMentionMessage().GetMessage()) ||
+		containsNestedProtocolMutation(msg.GetDeviceSentMessage().GetMessage()) ||
 		containsNestedProtocolMutation(msg.GetEditedMessage().GetMessage()) ||
 		containsNestedProtocolMutation(msg.GetCommentMessage().GetMessage())
 }

--- a/internal/app/sync_edits_wrappers_test.go
+++ b/internal/app/sync_edits_wrappers_test.go
@@ -1,0 +1,57 @@
+package app
+
+import (
+	"bytes"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openclaw/wacli/internal/wa"
+	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestSecretEditRejectsContentWrappedMutation(t *testing.T) {
+	for name, wrap := range map[string]func(*waE2E.Message) *waE2E.Message{
+		"associated-child": func(m *waE2E.Message) *waE2E.Message {
+			return &waE2E.Message{AssociatedChildMessage: &waE2E.FutureProofMessage{Message: m}}
+		},
+		"group-status": func(m *waE2E.Message) *waE2E.Message {
+			return &waE2E.Message{GroupStatusMentionMessage: &waE2E.FutureProofMessage{Message: m}}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			a := newTestApp(t)
+			f := newCryptoEditWA(t)
+			a.wa = f
+			chat := types.JID{User: "120363000000", Server: types.GroupServer}
+			sender := types.JID{User: "15550000001", Server: types.DefaultUserServer}
+			secret := bytes.Repeat([]byte{0x23}, 32)
+			if err := f.client.Store.MsgSecrets.PutMessageSecret(ctx, chat, sender, "original-id", secret); err != nil {
+				t.Fatal(err)
+			}
+			base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			original := &events.Message{Info: types.MessageInfo{MessageSource: types.MessageSource{Chat: chat, Sender: sender, IsGroup: true}, ID: "original-id", Timestamp: base}, Message: &waE2E.Message{Conversation: proto.String("original body")}}
+			var stored atomic.Int64
+			a.handleLiveSyncMessage(ctx, SyncOptions{}, original, &stored, func(string, string) {}, nil)
+			evt := &events.Message{Info: original.Info, Message: secretGroupEditEnvelope(chat, sender, "original-id")}
+			evt.Info.ID = "edit-envelope"
+			evt.Info.Timestamp = base.Add(time.Minute)
+			payload := decryptedProtocolEdit("outer body")
+			payload.ProtocolMessage.EditedMessage = wrap(decryptedProtocolEdit("nested body"))
+			encryptEditFixture(t, evt, sender, secret, payload)
+			webhooks := 0
+			a.handleLiveSyncMessage(ctx, SyncOptions{}, evt, &stored, func(string, string) {}, func(wa.ParsedMessage) { webhooks++ })
+			msg, err := a.db.GetMessage(chat.String(), "original-id")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if msg.Text != "original body" || msg.Edited || stored.Load() != 1 || webhooks != 0 {
+				t.Fatalf("nested edit accepted: %+v; stored=%d webhooks=%d", msg, stored.Load(), webhooks)
+			}
+		})
+	}
+}

--- a/internal/wa/messages.go
+++ b/internal/wa/messages.go
@@ -224,6 +224,9 @@ func extractWAProto(m *waProto.Message, pm *ParsedMessage) *waProto.Message {
 		}
 		return m
 	}
+	if inner := contentWrapper(m); inner != nil {
+		return extractWAProto(inner, pm)
+	}
 	if comment := m.GetCommentMessage(); comment.GetMessage() != nil {
 		leaf := extractWAProto(comment.GetMessage(), pm)
 		if target := comment.GetTargetMessageKey(); strings.TrimSpace(target.GetID()) != "" {
@@ -457,6 +460,8 @@ func extractPlainText(m *waProto.Message, pm *ParsedMessage) {
 		pm.Text = m.GetConversation()
 	case m.GetExtendedTextMessage() != nil:
 		pm.Text = m.GetExtendedTextMessage().GetText()
+	case m.GetGroupInviteMessage() != nil:
+		pm.Text = groupInviteText(m.GetGroupInviteMessage())
 	}
 }
 
@@ -488,4 +493,22 @@ func extractAlbum(m *waProto.Message, pm *ParsedMessage) {
 			pm.Text = "[Album]"
 		}
 	}
+}
+
+// These envelopes retain the outer identity while carrying ordinary content.
+func contentWrapper(m *waProto.Message) *waProto.Message {
+	if inner := m.GetAssociatedChildMessage().GetMessage(); inner != nil {
+		return inner
+	}
+	return m.GetGroupStatusMentionMessage().GetMessage()
+}
+
+func groupInviteText(invite *waE2E.GroupInviteMessage) string {
+	if caption := invite.GetCaption(); strings.TrimSpace(caption) != "" {
+		return caption
+	}
+	if name := strings.TrimSpace(invite.GetGroupName()); name != "" {
+		return "Group invite: " + name
+	}
+	return "[Group invite]"
 }

--- a/internal/wa/messages_composite_test.go
+++ b/internal/wa/messages_composite_test.go
@@ -59,3 +59,63 @@ func TestCommentKeepsUnhandledLeafDiagnostic(t *testing.T) {
 		t.Fatalf("empty comment diagnostic = %q", got)
 	}
 }
+
+func TestAssociatedAndGroupStatusContent(t *testing.T) {
+	for name, wrap := range map[string]func(*waProto.Message) *waProto.Message{
+		"associatedChildMessage": func(m *waProto.Message) *waProto.Message {
+			return &waProto.Message{AssociatedChildMessage: &waE2E.FutureProofMessage{Message: m}}
+		},
+		"groupStatusMentionMessage": func(m *waProto.Message) *waProto.Message {
+			return &waProto.Message{GroupStatusMentionMessage: &waE2E.FutureProofMessage{Message: m}}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := &waProto.ContextInfo{StanzaID: proto.String("quoted-id"), Participant: proto.String("15555550124@s.whatsapp.net"), QuotedMessage: &waProto.Message{Conversation: proto.String("quoted text")}, IsForwarded: proto.Bool(true)}
+			for _, media := range []bool{false, true} {
+				inner := &waProto.Message{ExtendedTextMessage: &waProto.ExtendedTextMessage{Text: proto.String("searchable body"), ContextInfo: ctx}}
+				if media {
+					inner = &waProto.Message{ImageMessage: &waProto.ImageMessage{Caption: proto.String("searchable body"), ContextInfo: ctx, DirectPath: proto.String("/synthetic/media"), MediaKey: []byte{1, 2, 3}}}
+				}
+				m := wrap(wrap(inner))
+				wantQuote := "searchable body"
+				if media {
+					wantQuote = "Sent image"
+				}
+				if got := displayTextForProto(m); got != wantQuote {
+					t.Fatalf("wrapped quote=%q want %q", got, wantQuote)
+				}
+				live := liveEvent(m)
+				live.Info.Sender = live.Info.Chat
+				hist := &waProto.WebMessageInfo{Key: &waCommon.MessageKey{ID: proto.String(live.Info.ID), RemoteJID: proto.String(live.Info.Chat.String()), Participant: proto.String(live.Info.Sender.String())}, Message: m}
+				for _, pm := range []ParsedMessage{ParseLiveMessage(live), ParseHistoryMessage(live.Info.Chat.String(), hist)} {
+					if pm.Text != "searchable body" || pm.ID != live.Info.ID || pm.Chat != live.Info.Chat || pm.SenderJID != live.Info.Sender.String() || pm.ReplyToID != "quoted-id" || pm.ReplyToDisplay != "quoted text" || !pm.IsForwarded || pm.UnhandledPayload != "" {
+						t.Fatalf("media=%t: %+v", media, pm)
+					}
+					if media && (pm.Media == nil || pm.Media.Type != "image" || pm.Media.DirectPath != "/synthetic/media") {
+						t.Fatalf("lost wrapped media: %+v", pm.Media)
+					}
+				}
+			}
+			if got := ParseLiveMessage(liveEvent(wrap(&waProto.Message{StickerSyncRmrMessage: &waProto.StickerSyncRMRMessage{Filehash: []string{"synthetic"}}}))).UnhandledPayload; got != "stickerSyncRmrMessage" {
+				t.Fatalf("leaf diagnostic=%q", got)
+			}
+			if got := ParseLiveMessage(liveEvent(wrap(nil))).UnhandledPayload; got != name {
+				t.Fatalf("empty wrapper diagnostic=%q", got)
+			}
+		})
+	}
+}
+
+func TestGroupInviteContentAndContext(t *testing.T) {
+	for _, tc := range []struct{ caption, name, want string }{{"join this discussion", "Readers", "join this discussion"}, {"", "Readers", "Group invite: Readers"}, {"", "", "[Group invite]"}} {
+		m := &waProto.Message{GroupInviteMessage: &waE2E.GroupInviteMessage{Caption: proto.String(tc.caption), GroupName: proto.String(tc.name), GroupJID: proto.String("120363000001@g.us"), InviteCode: proto.String("synthetic-invite-code"), ContextInfo: &waProto.ContextInfo{StanzaID: proto.String("invite-parent")}}}
+		for _, pm := range []ParsedMessage{ParseLiveMessage(liveEvent(m)), ParseHistoryMessage("15555550123@s.whatsapp.net", &waProto.WebMessageInfo{Message: m})} {
+			if pm.Text != tc.want || pm.ReplyToID != "invite-parent" || pm.UnhandledPayload != "" {
+				t.Fatalf("invite content=%+v", pm)
+			}
+		}
+		if got := displayTextForProto(m); got != tc.want {
+			t.Fatalf("quoted invite=%q want %q", got, tc.want)
+		}
+	}
+}

--- a/internal/wa/messages_context.go
+++ b/internal/wa/messages_context.go
@@ -68,6 +68,9 @@ func contextInfoForMessage(m *waProto.Message) *waProto.ContextInfo {
 	if creation := pickPollCreation(m); creation != nil {
 		return creation.GetContextInfo()
 	}
+	if invite := m.GetGroupInviteMessage(); invite != nil {
+		return invite.GetContextInfo()
+	}
 	if alb := m.GetAlbumMessage(); alb != nil {
 		return alb.GetContextInfo()
 	}
@@ -79,6 +82,12 @@ func displayTextForProto(m *waProto.Message) string {
 		return ""
 	}
 
+	if inner := contentWrapper(m); inner != nil {
+		return displayTextForProto(inner)
+	}
+	if invite := m.GetGroupInviteMessage(); invite != nil {
+		return groupInviteText(invite)
+	}
 	if img := m.GetImageMessage(); img != nil {
 		return "Sent image"
 	}


### PR DESCRIPTION
Associated-child and group-status-mention payloads were stored as opaque rows even when they contained ordinary text or media. Group-invite captions were also omitted. The shared live/history parser now unwraps these content envelopes, preserves the inner media and reply context, and exposes invitation captions (falling back to the group name). Quote summaries use the same content handling.

This fixes the confirmed remaining parser gaps in #365. Ordinary extended text was already supported; album/comment handling landed in #383. It does not establish the cause of the six all-empty groups or recover absent payloads/decryption keys, so #365 stays open for that investigation. Existing opaque rows change only when their payloads are re-ingested.

Regression fixtures fail on main for both wrappers and invitations, then pass after the repair. Tests cover live/history parsing, nested wrappers, media metadata, quote/forward context, empty and unsupported wrappers, invitation fallback, and wrapped encrypted-edit mutation rejection. Full repository validation and isolated Codex review at P0–P2 passed.

Compiled-CLI proof: synthetic live and history transport replayed eight group messages through the normal sync/store/FTS path. Before: five new payloads had no text and `messages search synthetic` returned two rows. After: all eight payloads retained their expected text, the image retained its media type, six context-bearing rows retained quote/forward metadata, and the same FTS search returned seven rows. Existing extended text, album summary, and comment body were unchanged. This exercises the executable and local SQLite/FTS paths, not a live WhatsApp account.

Commands: `go build -overlay <synthetic-transport-overlay.json> -tags sqlite_fts5 ./cmd/wacli`; `wacli --store <synthetic-store> --json sync --once --idle-exit 50ms`; `wacli --store <synthetic-store> --read-only --json messages search synthetic`. Both baseline and fixed executables were run in live/history modes. A further 42 compiled encrypted-edit replay scenarios (including both new wrappers) preserve the author/target checks: nested edits leave the original body and edited flag unchanged and emit no edit webhook.

No schema, CLI flag, dependency, or version changes.
